### PR TITLE
Cpp/bug/move deref

### DIFF
--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -168,12 +168,31 @@ public:
 
   ~BDD()
   {
-    if (Cal_BddIsBddNull(this->_bddManager, this->_bdd) == 0)
-      Cal_BddFree(this->_bddManager, this->_bdd);
+    this->Free();
   }
 
   // ---------------------------------------------------------------------------
   // TODO: Operators functions as member functions?
+
+  // ---------------------------------------------------------------------------
+  // Predicates
+  bool IsNull() const
+  { return Cal_BddIsBddNull(this->_bddManager, this->_bdd); }
+
+  bool IsOne() const
+  { return Cal_BddIsBddOne(this->_bddManager, this->_bdd); }
+
+  bool IsZero() const
+  { return Cal_BddIsBddZero(this->_bddManager, this->_bdd); }
+
+  bool IsConst() const
+  { return Cal_BddIsBddConst(this->_bddManager, this->_bdd); }
+
+  bool IsCube() const
+  { return Cal_BddIsCube(this->_bddManager, this->_bdd); }
+
+  bool IsEqual(const BDD &other) const
+  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
 
   // ---------------------------------------------------------------------------
   // Node traversal

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -88,12 +88,20 @@ public:
 
   // ---------------------------------------------------------------------------
   // Declaration of BDD Constructors
-  BDD Null();
-  BDD One();
-  BDD Zero();
+  BDD Null() const;
+  BDD One() const;
+  BDD Zero() const;
+  BDD Id(Cal_BddId_t id) const;
+  BDD Index(Cal_BddIndex_t idx) const;
 
-  BDD Id(Cal_BddId_t id);
-  BDD Index(Cal_BddIndex_t idx);
+  // Declaration of BDD Predicates
+  bool IsNull(BDD f) const;
+  bool IsNotNull(BDD f) const;
+  bool IsOne(BDD f) const;
+  bool IsZero(BDD f) const;
+  bool IsConst(BDD f) const;
+  bool IsCube(BDD f) const;
+  bool IsEqual(BDD f, BDD g) const;
 
   // Declaration of BDD Operations
   BDD Else(BDD f);
@@ -289,20 +297,42 @@ int Cal::AssociationSetCurrent(int i)
 { return Cal_AssociationSetCurrent(_bddManager, i); }
 
 // -----------------------------------------------------------------------------
-BDD Cal::Null()
+BDD Cal::Null() const
 { return BDD(_bddManager, Cal_BddNull(_bddManager)); }
 
-BDD Cal::One()
+BDD Cal::One() const
 { return BDD(_bddManager, Cal_BddOne(_bddManager)); }
 
-BDD Cal::Zero()
+BDD Cal::Zero() const
 { return BDD(_bddManager, Cal_BddZero(_bddManager)); }
 
-BDD Cal::Id(Cal_BddId_t id)
+BDD Cal::Id(Cal_BddId_t id) const
 { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, id)); }
 
-BDD Cal::Index(Cal_BddIndex_t idx)
+BDD Cal::Index(Cal_BddIndex_t idx) const
 { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
+
+// -----------------------------------------------------------------------------
+bool Cal::IsNull(BDD f) const
+{ return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
+
+bool Cal::IsNotNull(BDD f) const
+{ return Cal_BddIsBddNull(_bddManager, f._bdd) != 1; }
+
+bool Cal::IsOne(BDD f) const
+{ return Cal_BddIsBddOne(_bddManager, f._bdd) == 1; }
+
+bool Cal::IsZero(BDD f) const
+{ return Cal_BddIsBddZero(_bddManager, f._bdd) == 1; }
+
+bool Cal::IsConst(BDD f) const
+{ return Cal_BddIsBddConst(_bddManager, f._bdd) == 1; }
+
+bool Cal::IsCube(BDD f) const
+{ return Cal_BddIsCube(_bddManager, f._bdd) == 1; }
+
+bool Cal::IsEqual(BDD f, BDD g) const
+{ return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
 
 // -----------------------------------------------------------------------------
 BDD Cal::Else(BDD f)

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -271,6 +271,39 @@ private:
   inline void
   UnFree()
   { if (!this->IsNull()) Cal_BddUnFree(this->_bddManager, this->_bdd); }
+
+public:
+  // ---------------------------------------------------------------------------
+  // Debugging
+  int RefCount() const
+  {
+    if (this->IsNull()) {
+      return 255; // <-- Simulate NULL has fixed MAX reference count.
+    }
+
+    CalBddNode_t *internal_node = CAL_BDD_POINTER(this->_bdd);
+
+    int res;
+    CalBddNodeGetRefCount(internal_node, res);
+
+    return res;
+  }
+
+  std::string ToString() const
+  {
+    if (this->IsNull()) { return "NULL"; }
+    if (this->IsZero()) { return "(0)"; }
+    if (this->IsOne())  { return "(1)"; }
+
+    std::stringstream ss;
+    ss << "("
+       << this->Id() << ", "
+       << this->Then()._bdd << ", "
+       << this->Else()._bdd
+       << ")";
+
+    return ss.str();
+  }
 };
 
 // -----------------------------------------------------------------------------

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -223,6 +223,8 @@ public:
 
   BDD& operator= (BDD &&other)
   {
+    this->Free();
+
     this->_bdd = other._bdd;
     this->_bddManager = other._bddManager;
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -202,9 +202,6 @@ public:
   Cal_BddIndex_t Index() const
   { return Cal_BddGetIfIndex(this->_bddManager, this->_bdd); }
 
-  BDD If() const
-  { return BDD(this->_bddManager, Cal_BddIf(this->_bddManager, this->_bdd)); }
-
   BDD Then() const
   { return BDD(this->_bddManager, Cal_BddThen(this->_bddManager, this->_bdd)); }
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -43,11 +43,6 @@ public:
   // TODO: allow multiple copies to access Cal
   Cal(const Cal &o) = delete;
 
-  /*
-  Cal(const Cal &o) : _bddManager(o._bddManager)
-  { }
-  */
-
   ~Cal()
   {
     Cal_BddManagerQuit(_bddManager);

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -2,8 +2,8 @@
 #define _CALOBJ
 
 extern "C" {
-  #include <cal.h>
-  #include <calInt.h>
+#include <cal.h>
+#include <calInt.h>
 }
 
 // -----------------------------------------------------------------------------

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -143,8 +143,8 @@ protected:
   BDD(Cal_BddManager bddManager, Cal_Bdd bdd)
     : _bddManager(bddManager), _bdd(bdd)
   {
-    // No need to call Cal_BddUnFree, since it already is reference counted on
-    // the return from one of Cal's operations.
+    // No need to UnFree(), since it already is reference counted on the return
+    // from one of Cal's operations.
   }
 
 public:
@@ -155,9 +155,7 @@ public:
   BDD(const BDD &other)
     : _bddManager(other._bddManager), _bdd(other._bdd)
   {
-    if (Cal_BddIsBddNull(this->_bddManager, this->_bdd) == 0) {
-      Cal_BddUnFree(this->_bddManager, this->_bdd);
-    }
+    this->UnFree();
   }
 
   BDD(BDD &&other)
@@ -213,16 +211,12 @@ public:
 
   BDD& operator= (const BDD &other)
   {
-    if (Cal_BddIsBddNull(this->_bddManager, this->_bdd) == 0) {
-      Cal_BddFree(this->_bddManager, this->_bdd);
-    }
+    this->Free();
 
     this->_bdd = other._bdd;
     this->_bddManager = other._bddManager;
 
-    if (Cal_BddIsBddNull(this->_bddManager, this->_bdd) == 0) {
-      Cal_BddUnFree(this->_bddManager, this->_bdd);
-    }
+    this->UnFree();
 
     return *this;
   }
@@ -263,6 +257,18 @@ public:
 
   BDD& operator^= (const BDD &other)
   { return (*this = (*this) ^ other); }
+
+private:
+  // ---------------------------------------------------------------------------
+  // Memory Management
+
+  inline void
+  Free()
+  { if (!this->IsNull()) Cal_BddFree(this->_bddManager, this->_bdd); }
+
+  inline void
+  UnFree()
+  { if (!this->IsNull()) Cal_BddUnFree(this->_bddManager, this->_bdd); }
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a memory leak due to a missing dereference in the move-constructor ( closes #15 ). Furthermore, this also further cleans up and expands on the C++ interface ( #8 )