### PR TITLE
Api cleanup

### DIFF
--- a/src/cal.c
+++ b/src/cal.c
@@ -640,9 +640,9 @@ Cal_BddStats(Cal_BddManager bddManager, FILE * fp)
 
 /**Function********************************************************************
 
-  Synopsis    [Specify dynamic reordering technique.]
+  Synopsis    [Specify dynamic reordering technique and method.]
 
-  Description [Selects the method for dynamic reordering.]
+  Description [Selects the technique andmethod for dynamic reordering.]
 
   SideEffects [None]
 
@@ -650,9 +650,10 @@ Cal_BddStats(Cal_BddManager bddManager, FILE * fp)
 
 ******************************************************************************/
 void
-Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique)
+Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique, int method)
 {
   bddManager->reorderTechnique = technique;
+  bddManager->reorderMethod = method;
 }
 
 /**Function********************************************************************

--- a/src/cal.h
+++ b/src/cal.h
@@ -246,11 +246,14 @@ EXTERN void Cal_BddFunctionPrint(Cal_BddManager bddManager, Cal_Bdd userBdd, cha
 // Copy
 EXTERN Cal_Bdd Cal_BddIdentity(Cal_BddManager bddManager, Cal_Bdd userBdd);
 
-// Compose
-EXTERN Cal_Bdd Cal_BddCompose(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
-
 // Without complementation falg
 EXTERN Cal_Bdd Cal_BddGetRegular(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+// Not
+EXTERN Cal_Bdd Cal_BddNot(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+// Compose
+EXTERN Cal_Bdd Cal_BddCompose(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
 
 // Intersects
 EXTERN Cal_Bdd Cal_BddIntersects(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
@@ -261,22 +264,25 @@ EXTERN Cal_Bdd Cal_BddImplies(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_B
 // If-Then-Else
 EXTERN Cal_Bdd Cal_BddITE(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
 
-// Not
-EXTERN Cal_Bdd Cal_BddNot(Cal_BddManager bddManager, Cal_Bdd userBdd);
-
 // Apply
 EXTERN Cal_Bdd Cal_BddAnd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+EXTERN Cal_Bdd Cal_BddMultiwayAnd(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
+
 EXTERN Cal_Bdd Cal_BddNand(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+
 EXTERN Cal_Bdd Cal_BddOr(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+EXTERN Cal_Bdd Cal_BddMultiwayOr(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
+
 EXTERN Cal_Bdd Cal_BddNor(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+
 EXTERN Cal_Bdd Cal_BddXor(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+EXTERN Cal_Bdd Cal_BddMultiwayXor(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
+
 EXTERN Cal_Bdd Cal_BddXnor(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+
 EXTERN Cal_Bdd * Cal_BddPairwiseAnd(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
 EXTERN Cal_Bdd * Cal_BddPairwiseOr(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
 EXTERN Cal_Bdd * Cal_BddPairwiseXor(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
-EXTERN Cal_Bdd Cal_BddMultiwayAnd(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
-EXTERN Cal_Bdd Cal_BddMultiwayOr(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
-EXTERN Cal_Bdd Cal_BddMultiwayXor(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
 
 // Sat
 EXTERN Cal_Bdd Cal_BddSatisfy(Cal_BddManager bddManager, Cal_Bdd fUserBdd);

--- a/src/cal.h
+++ b/src/cal.h
@@ -167,7 +167,7 @@ EXTERN void Cal_MemFreeRecMgr(Cal_RecMgr mgr);
 /*---------------------------------------------------------------------------*/
 /* | Variable Reordering                                                     */
 /*---------------------------------------------------------------------------*/
-EXTERN void Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique);
+EXTERN void Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique, int method);
 EXTERN void Cal_BddReorder(Cal_BddManager bddManager);
 EXTERN Cal_Block Cal_BddNewVarBlock(Cal_BddManager bddManager, Cal_Bdd variable, long length);
 EXTERN void Cal_BddVarBlockReorderable(Cal_BddManager bddManager, Cal_Block block, int reorderable);

--- a/src/cal.h
+++ b/src/cal.h
@@ -96,8 +96,8 @@ typedef struct Cal_BddManagerStruct Cal_BddManager_t;
 typedef struct CalBddNodeStruct *Cal_Bdd;
 typedef unsigned short int Cal_BddId_t;
 typedef unsigned short int Cal_BddIndex_t;
-typedef char * (*Cal_VarNamingFn_t)(Cal_BddManager, Cal_Bdd, Cal_Pointer_t); 
-typedef char * (*Cal_TerminalIdFn_t)(Cal_BddManager, Cal_Address_t, Cal_Address_t, Cal_Pointer_t);      
+typedef char * (*Cal_VarNamingFn_t)(Cal_BddManager, Cal_Bdd, Cal_Pointer_t);
+typedef char * (*Cal_TerminalIdFn_t)(Cal_BddManager, Cal_Address_t, Cal_Address_t, Cal_Pointer_t);
 typedef struct Cal_BlockStruct *Cal_Block;
 
 /*---------------------------------------------------------------------------*/
@@ -118,63 +118,153 @@ typedef enum Cal_BddOpEnum Cal_BddOp_t;
 #define Cal_BddTerminalIdFnNone ((char *(*)(Cal_BddManager, Cal_Address_t, Cal_Address_t, Cal_Pointer_t))0)
 #define Cal_Assert(valid) assert(valid)
 
-
-
 /**AutomaticStart*************************************************************/
 
 /*---------------------------------------------------------------------------*/
-/* Function prototypes                                                       */
+/* CAL Manager                                                               */
 /*---------------------------------------------------------------------------*/
+EXTERN Cal_BddManager Cal_BddManagerInit();
+EXTERN int Cal_BddManagerQuit(Cal_BddManager bddManager);
 
-EXTERN int Cal_BddIsEqual(Cal_BddManager bddManager, Cal_Bdd userBdd1, Cal_Bdd userBdd2);
-EXTERN int Cal_BddIsBddOne(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN int Cal_BddIsBddZero(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN int Cal_BddIsBddNull(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN int Cal_BddIsBddConst(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddIdentity(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddOne(Cal_BddManager bddManager);
-EXTERN Cal_Bdd Cal_BddZero(Cal_BddManager bddManager);
-EXTERN Cal_Bdd Cal_BddNull(Cal_BddManager bddManager);
-EXTERN Cal_Bdd Cal_BddNot(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_BddId_t Cal_BddGetIfIndex(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_BddId_t Cal_BddGetIfId(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddIf(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddThen(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddElse(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN void Cal_BddFree(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN void Cal_BddUnFree(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddGetRegular(Cal_BddManager bddManager, Cal_Bdd userBdd);
-EXTERN Cal_Bdd Cal_BddIntersects(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
-EXTERN Cal_Bdd Cal_BddImplies(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
-EXTERN unsigned long Cal_BddTotalSize(Cal_BddManager bddManager);
-EXTERN void Cal_BddStats(Cal_BddManager bddManager, FILE * fp);
-EXTERN void Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique);
-EXTERN void Cal_BddReorder(Cal_BddManager bddManager);
-EXTERN int Cal_BddType(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN long Cal_BddVars(Cal_BddManager bddManager);
-EXTERN long Cal_BddNodeLimit(Cal_BddManager bddManager, long newLimit);
-EXTERN int Cal_BddOverflow(Cal_BddManager bddManager);
-EXTERN int Cal_BddIsCube(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+/*---------------------------------------------------------------------------*/
+/* | Hooks and Parameters                                                    */
+/*---------------------------------------------------------------------------*/
 EXTERN void * Cal_BddManagerGetHooks(Cal_BddManager bddManager);
 EXTERN void Cal_BddManagerSetHooks(Cal_BddManager bddManager, void *hooks);
+EXTERN void Cal_BddManagerSetParameters(Cal_BddManager bddManager, long reorderingThreshold, long maxForwardedNodes, double repackAfterGCThreshold, double tableRepackThreshold);
+
+/*---------------------------------------------------------------------------*/
+/* | Statistics and Information                                              */
+/*---------------------------------------------------------------------------*/
+EXTERN unsigned long Cal_BddManagerGetNumNodes(Cal_BddManager bddManager);
+EXTERN long Cal_BddVars(Cal_BddManager bddManager);
+EXTERN int Cal_BddOverflow(Cal_BddManager bddManager);
+EXTERN unsigned long Cal_BddTotalSize(Cal_BddManager bddManager);
+EXTERN void Cal_BddStats(Cal_BddManager bddManager, FILE * fp);
+
+/*---------------------------------------------------------------------------*/
+/* | Memory and Garbage Collection                                           */
+/*---------------------------------------------------------------------------*/
+EXTERN long Cal_BddNodeLimit(Cal_BddManager bddManager, long newLimit);
+EXTERN void Cal_BddSetGCMode(Cal_BddManager bddManager, int gcMode);
+EXTERN void Cal_BddManagerSetGCLimit(Cal_BddManager manager);
+EXTERN int Cal_BddManagerGC(Cal_BddManager bddManager);
+
+/*---------------------------------------------------------------------------*/
+/* | Memory (internal)                                                       */
+/*---------------------------------------------------------------------------*/
+EXTERN void Cal_MemFatal(char *message);
+
+EXTERN Cal_Address_t Cal_MemAllocation(void);
+EXTERN Cal_Pointer_t Cal_MemGetBlock(Cal_Address_t size);
+EXTERN void Cal_MemFreeBlock(Cal_Pointer_t p);
+EXTERN Cal_Pointer_t Cal_MemResizeBlock(Cal_Pointer_t p, Cal_Address_t newSize);
+EXTERN Cal_Pointer_t Cal_MemNewRec(Cal_RecMgr mgr);
+EXTERN void Cal_MemFreeRec(Cal_RecMgr mgr, Cal_Pointer_t rec);
+EXTERN Cal_RecMgr Cal_MemNewRecMgr(int size);
+EXTERN void Cal_MemFreeRecMgr(Cal_RecMgr mgr);
+
+/*---------------------------------------------------------------------------*/
+/* | Variable Reordering                                                     */
+/*---------------------------------------------------------------------------*/
+EXTERN void Cal_BddDynamicReordering(Cal_BddManager bddManager, int technique);
+EXTERN void Cal_BddReorder(Cal_BddManager bddManager);
+EXTERN Cal_Block Cal_BddNewVarBlock(Cal_BddManager bddManager, Cal_Bdd variable, long length);
+EXTERN void Cal_BddVarBlockReorderable(Cal_BddManager bddManager, Cal_Block block, int reorderable);
+
+/*---------------------------------------------------------------------------*/
+/* | Association List                                                        */
+/*---------------------------------------------------------------------------*/
 EXTERN int Cal_AssociationInit(Cal_BddManager bddManager, Cal_Bdd *associationInfoUserBdds, int pairs);
 EXTERN void Cal_AssociationQuit(Cal_BddManager bddManager, int associationId);
 EXTERN int Cal_AssociationSetCurrent(Cal_BddManager bddManager, int associationId);
 EXTERN void Cal_TempAssociationAugment(Cal_BddManager bddManager, Cal_Bdd *associationInfoUserBdds, int pairs);
 EXTERN void Cal_TempAssociationInit(Cal_BddManager bddManager, Cal_Bdd *associationInfoUserBdds, int pairs);
 EXTERN void Cal_TempAssociationQuit(Cal_BddManager bddManager);
-EXTERN Cal_Bdd Cal_BddCompose(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
-EXTERN Cal_Bdd Cal_BddITE(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
-EXTERN Cal_BddManager Cal_BddManagerInit();
-EXTERN int Cal_BddManagerQuit(Cal_BddManager bddManager);
-EXTERN void Cal_BddManagerSetParameters(Cal_BddManager bddManager, long reorderingThreshold, long maxForwardedNodes, double repackAfterGCThreshold, double tableRepackThreshold);
-EXTERN unsigned long Cal_BddManagerGetNumNodes(Cal_BddManager bddManager);
+
+/*---------------------------------------------------------------------------*/
+/* | Save / Load of BDDs                                                     */
+/*---------------------------------------------------------------------------*/
+EXTERN Cal_Bdd Cal_BddUndumpBdd(Cal_BddManager bddManager, Cal_Bdd * userVars, FILE * fp, int * error);
+EXTERN int Cal_BddDumpBdd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd * userVars, FILE * fp);
+
+/*---------------------------------------------------------------------------*/
+/* BDD                                                                       */
+/*---------------------------------------------------------------------------*/
+EXTERN void Cal_BddFree(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN void Cal_BddUnFree(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+/*---------------------------------------------------------------------------*/
+/* | Basic Constructors                                                      */
+/*---------------------------------------------------------------------------*/
+EXTERN Cal_Bdd Cal_BddNull(Cal_BddManager bddManager);
+EXTERN Cal_Bdd Cal_BddOne(Cal_BddManager bddManager);
+EXTERN Cal_Bdd Cal_BddZero(Cal_BddManager bddManager);
+
 EXTERN Cal_Bdd Cal_BddManagerCreateNewVarFirst(Cal_BddManager bddManager);
 EXTERN Cal_Bdd Cal_BddManagerCreateNewVarLast(Cal_BddManager bddManager);
 EXTERN Cal_Bdd Cal_BddManagerCreateNewVarBefore(Cal_BddManager bddManager, Cal_Bdd userBdd);
 EXTERN Cal_Bdd Cal_BddManagerCreateNewVarAfter(Cal_BddManager bddManager, Cal_Bdd userBdd);
 EXTERN Cal_Bdd Cal_BddManagerGetVarWithIndex(Cal_BddManager bddManager, Cal_BddIndex_t index);
 EXTERN Cal_Bdd Cal_BddManagerGetVarWithId(Cal_BddManager bddManager, Cal_BddId_t id);
+
+/*---------------------------------------------------------------------------*/
+/* | Predicates                                                              */
+/*---------------------------------------------------------------------------*/
+EXTERN int Cal_BddIsBddNull(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN int Cal_BddIsBddOne(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN int Cal_BddIsBddZero(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN int Cal_BddIsBddConst(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN int Cal_BddIsCube(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+EXTERN int Cal_BddIsEqual(Cal_BddManager bddManager, Cal_Bdd userBdd1, Cal_Bdd userBdd2);
+EXTERN int Cal_BddDependsOn(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd varUserBdd);
+
+/*---------------------------------------------------------------------------*/
+/* | Information                                                             */
+/*---------------------------------------------------------------------------*/
+EXTERN double Cal_BddSatisfyingFraction(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+EXTERN long Cal_BddSize(Cal_BddManager bddManager, Cal_Bdd fUserBdd, int negout);
+EXTERN long Cal_BddSizeMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, int negout);
+EXTERN void Cal_BddSupport(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd *support);
+
+EXTERN void Cal_BddProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, long * levelCounts, int negout);
+EXTERN void Cal_BddProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, long * levelCounts, int negout);
+EXTERN void Cal_BddFunctionProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, long * funcCounts);
+EXTERN void Cal_BddFunctionProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, long * funcCounts);
+
+EXTERN void Cal_BddPrintBdd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_VarNamingFn_t VarNamingFn, Cal_TerminalIdFn_t TerminalIdFn, Cal_Pointer_t env, FILE *fp);
+EXTERN void Cal_BddPrintProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
+EXTERN void Cal_BddPrintProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *userBdds, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
+EXTERN void Cal_BddPrintFunctionProfile(Cal_BddManager bddManager, Cal_Bdd f, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
+EXTERN void Cal_BddPrintFunctionProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *userBdds, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
+EXTERN void Cal_BddFunctionPrint(Cal_BddManager bddManager, Cal_Bdd userBdd, char *name);
+
+/*---------------------------------------------------------------------------*/
+/* | Manipulation                                                            */
+/*---------------------------------------------------------------------------*/
+
+// Copy
+EXTERN Cal_Bdd Cal_BddIdentity(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+// Compose
+EXTERN Cal_Bdd Cal_BddCompose(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
+
+// Without complementation falg
+EXTERN Cal_Bdd Cal_BddGetRegular(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+// Intersects
+EXTERN Cal_Bdd Cal_BddIntersects(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+
+// Implies
+EXTERN Cal_Bdd Cal_BddImplies(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+
+// If-Then-Else
+EXTERN Cal_Bdd Cal_BddITE(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
+
+// Not
+EXTERN Cal_Bdd Cal_BddNot(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+// Apply
 EXTERN Cal_Bdd Cal_BddAnd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
 EXTERN Cal_Bdd Cal_BddNand(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
 EXTERN Cal_Bdd Cal_BddOr(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
@@ -187,36 +277,41 @@ EXTERN Cal_Bdd * Cal_BddPairwiseXor(Cal_BddManager bddManager, Cal_Bdd *userBddA
 EXTERN Cal_Bdd Cal_BddMultiwayAnd(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
 EXTERN Cal_Bdd Cal_BddMultiwayOr(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
 EXTERN Cal_Bdd Cal_BddMultiwayXor(Cal_BddManager bddManager, Cal_Bdd *userBddArray);
+
+// Sat
 EXTERN Cal_Bdd Cal_BddSatisfy(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
 EXTERN Cal_Bdd Cal_BddSatisfySupport(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN double Cal_BddSatisfyingFraction(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN long Cal_BddSize(Cal_BddManager bddManager, Cal_Bdd fUserBdd, int negout);
-EXTERN long Cal_BddSizeMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, int negout);
-EXTERN void Cal_BddProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, long * levelCounts, int negout);
-EXTERN void Cal_BddProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, long * levelCounts, int negout);
-EXTERN void Cal_BddFunctionProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, long * funcCounts);
-EXTERN void Cal_BddFunctionProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *fUserBddArray, long * funcCounts);
+
+// Compose + Association List
 EXTERN Cal_Bdd Cal_BddSubstitute(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN void Cal_BddSupport(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd *support);
-EXTERN int Cal_BddDependsOn(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd varUserBdd);
-EXTERN Cal_Bdd Cal_BddSwapVars(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
 EXTERN Cal_Bdd Cal_BddVarSubstitute(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN Cal_Block Cal_BddNewVarBlock(Cal_BddManager bddManager, Cal_Bdd variable, long length);
-EXTERN void Cal_BddVarBlockReorderable(Cal_BddManager bddManager, Cal_Block block, int reorderable);
-EXTERN Cal_Bdd Cal_BddUndumpBdd(Cal_BddManager bddManager, Cal_Bdd * userVars, FILE * fp, int * error);
-EXTERN int Cal_BddDumpBdd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd * userVars, FILE * fp);
-EXTERN void Cal_BddSetGCMode(Cal_BddManager bddManager, int gcMode);
-EXTERN int Cal_BddManagerGC(Cal_BddManager bddManager);
-EXTERN void Cal_BddManagerSetGCLimit(Cal_BddManager manager);
-EXTERN void Cal_MemFatal(char *message);
-EXTERN Cal_Address_t Cal_MemAllocation(void);
-EXTERN Cal_Pointer_t Cal_MemGetBlock(Cal_Address_t size);
-EXTERN void Cal_MemFreeBlock(Cal_Pointer_t p);
-EXTERN Cal_Pointer_t Cal_MemResizeBlock(Cal_Pointer_t p, Cal_Address_t newSize);
-EXTERN Cal_Pointer_t Cal_MemNewRec(Cal_RecMgr mgr);
-EXTERN void Cal_MemFreeRec(Cal_RecMgr mgr, Cal_Pointer_t rec);
-EXTERN Cal_RecMgr Cal_MemNewRecMgr(int size);
-EXTERN void Cal_MemFreeRecMgr(Cal_RecMgr mgr);
+
+// Swapping two variables
+EXTERN Cal_Bdd Cal_BddSwapVars(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd, Cal_Bdd hUserBdd);
+
+// Quantification
+EXTERN Cal_Bdd Cal_BddExists(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+EXTERN Cal_Bdd Cal_BddForAll(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+
+// Model Checking
+EXTERN Cal_Bdd Cal_BddRelProd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
+EXTERN Cal_Bdd Cal_BddCofactor(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd cUserBdd);
+EXTERN Cal_Bdd Cal_BddReduce(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd cUserBdd);
+EXTERN Cal_Bdd Cal_BddBetween(Cal_BddManager bddManager, Cal_Bdd fMinUserBdd, Cal_Bdd fMaxUserBdd);
+
+/*---------------------------------------------------------------------------*/
+/* | Node Information and Traversal                                          */
+/*---------------------------------------------------------------------------*/
+EXTERN int Cal_BddType(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
+EXTERN Cal_BddId_t Cal_BddGetIfIndex(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN Cal_BddId_t Cal_BddGetIfId(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN Cal_Bdd Cal_BddIf(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN Cal_Bdd Cal_BddThen(Cal_BddManager bddManager, Cal_Bdd userBdd);
+EXTERN Cal_Bdd Cal_BddElse(Cal_BddManager bddManager, Cal_Bdd userBdd);
+
+/*---------------------------------------------------------------------------*/
+/* Pipelined BDD Manipulation                                                */
+/*---------------------------------------------------------------------------*/
 EXTERN void Cal_PipelineSetDepth(Cal_BddManager bddManager, int depth);
 EXTERN int Cal_PipelineInit(Cal_BddManager bddManager, Cal_BddOp_t bddOp);
 EXTERN Cal_Bdd Cal_PipelineCreateProvisionalBdd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
@@ -224,18 +319,6 @@ EXTERN int Cal_PipelineExecute(Cal_BddManager bddManager);
 EXTERN Cal_Bdd Cal_PipelineUpdateProvisionalBdd(Cal_BddManager bddManager, Cal_Bdd provisionalBdd);
 EXTERN int Cal_BddIsProvisional(Cal_BddManager bddManager, Cal_Bdd userBdd);
 EXTERN void Cal_PipelineQuit(Cal_BddManager bddManager);
-EXTERN void Cal_BddPrintBdd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_VarNamingFn_t VarNamingFn, Cal_TerminalIdFn_t TerminalIdFn, Cal_Pointer_t env, FILE *fp);
-EXTERN void Cal_BddPrintProfile(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
-EXTERN void Cal_BddPrintProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *userBdds, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
-EXTERN void Cal_BddPrintFunctionProfile(Cal_BddManager bddManager, Cal_Bdd f, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
-EXTERN void Cal_BddPrintFunctionProfileMultiple(Cal_BddManager bddManager, Cal_Bdd *userBdds, Cal_VarNamingFn_t varNamingProc, char * env, int lineLength, FILE * fp);
-EXTERN Cal_Bdd Cal_BddExists(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN Cal_Bdd Cal_BddRelProd(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd gUserBdd);
-EXTERN Cal_Bdd Cal_BddForAll(Cal_BddManager bddManager, Cal_Bdd fUserBdd);
-EXTERN Cal_Bdd Cal_BddCofactor(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd cUserBdd);
-EXTERN Cal_Bdd Cal_BddReduce(Cal_BddManager bddManager, Cal_Bdd fUserBdd, Cal_Bdd cUserBdd);
-EXTERN Cal_Bdd Cal_BddBetween(Cal_BddManager bddManager, Cal_Bdd fMinUserBdd, Cal_Bdd fMaxUserBdd);
-EXTERN void Cal_BddFunctionPrint(Cal_BddManager bddManager, Cal_Bdd userBdd, char *name);
 
 /**AutomaticEnd***************************************************************/
 

--- a/src/calBddManager.c
+++ b/src/calBddManager.c
@@ -266,7 +266,7 @@ Cal_BddManagerInit( )
   bddManager->currentAssociation = bddManager->tempAssociation;
 
   /* BDD reordering related information */
-  bddManager->reorderMethod = CAL_REORDER_METHOD_BF;
+  bddManager->reorderMethod = CAL_REORDER_METHOD_DF;
   bddManager->reorderTechnique = CAL_REORDER_NONE;
   bddManager->numForwardedNodes = 0;
   bddManager->numReorderings = 0;

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -54,7 +54,41 @@ public:
   }
 
   // ---------------------------------------------------------------------------
-  // Definition of Operations
+  // Settings + Statistics
+
+  unsigned long GetNumNodes()
+  { return Cal_BddManagerGetNumNodes(_bddManager); }
+
+  long Vars()
+  { return Cal_BddVars(_bddManager); }
+
+  bool Overflow()
+  { return Cal_BddOverflow(_bddManager); }
+
+  unsigned long TotalSize()
+  { return Cal_BddTotalSize(_bddManager); }
+
+  void Stats(FILE* fp = stdout)
+  { Cal_BddStats(_bddManager, fp); }
+
+  // ---------------------------------------------------------------------------
+  // Memory and Garbage Collection
+
+  long NodeLimit(long newLimit)
+  { return Cal_BddNodeLimit(_bddManager, newLimit); }
+
+  void SetGCMode(bool enableGC)
+  { Cal_BddSetGCMode(_bddManager, enableGC); }
+
+  void SetGCLimit()
+  { Cal_BddManagerSetGCLimit(_bddManager); }
+
+  void GC()
+  { Cal_BddManagerGC(_bddManager); }
+
+  // ---------------------------------------------------------------------------
+  // Reordering
+
   enum ReorderTechnique {
     NONE = CAL_REORDER_NONE,
     SIFT = CAL_REORDER_SIFT,
@@ -67,72 +101,110 @@ public:
   void Reorder()
   { Cal_BddReorder(_bddManager); }
 
-  void SetGCMode(bool enableGC)
-  { Cal_BddSetGCMode(_bddManager, enableGC); }
-
-  void GC()
-  { Cal_BddManagerGC(_bddManager); }
-
-  unsigned long GetNumNodes()
-  { return Cal_BddManagerGetNumNodes(_bddManager); }
-
-  long Vars()
-  { return Cal_BddVars(_bddManager); }
-
-  void Stats(FILE* fp = stdout)
-  { Cal_BddStats(_bddManager, fp); }
+  // SwapVars(BDD x, BDD y);
 
   // ---------------------------------------------------------------------------
   // Declaration of Association List
+
   template<typename BDD_IT>
   int AssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false);
-
   void AssociationQuit(int i);
-
   int AssociationSetCurrent(int i);
+  // void TempAssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false);
+  // void TempAssociationAugment(BDD_IT begin, const BDD_IT end, const bool pairs = false);
+  // void TempAssociationQuit();
 
   // ---------------------------------------------------------------------------
-  // Declaration of BDD Constructors
+  // Save / Load BDDs
+
+  // BDD UndumpBdd(IT vars_begin, IT vars_end, FILE *f, int &error)
+  // BDD DumpBdd(BDD f, IT vars_begin, IT vars_end, FILE *f, int &error)
+
+  // ---------------------------------------------------------------------------
+  // BDD Constructors
   BDD Null() const;
   BDD One() const;
   BDD Zero() const;
   BDD Id(Cal_BddId_t id) const;
   BDD Index(Cal_BddIndex_t idx) const;
 
-  // Declaration of BDD Predicates
+  // BDD CreateNewVarFirst();
+  // BDD CreateNewVarFirst();
+  // BDD CreateNewVarBefore(BDD x);
+  // BDD CreateNewVarAfter(BDD x);
+  // BDD CreateNewVarWithIndex(BDD x, Cal_BddIndex_t index);
+  // BDD CreateNewVarWithId(Cal_BddId_t id);
+
+  // ---------------------------------------------------------------------------
+  // BDD Predicates
   bool IsNull(BDD f) const;
-  bool IsNotNull(BDD f) const;
   bool IsOne(BDD f) const;
   bool IsZero(BDD f) const;
   bool IsConst(BDD f) const;
   bool IsCube(BDD f) const;
   bool IsEqual(BDD f, BDD g) const;
+  // bool DependsOn(BDD f, BDD vars) const;
 
-  // Declaration of BDD Operations
-  BDD Else(BDD f);
+  // ---------------------------------------------------------------------------
+  // BDD Information
+  double SatisfyingFraction(BDD f);
+  unsigned long Size(BDD f);
+  // unsigned long Size(IT begin, IT end, bool negout); (using MultipleSize)
+  // container_t<BDD> Support(BDD f);
+
+  // ---------------------------------------------------------------------------
+  // Manipulation
+
+  // BDD Identity(BDD f) const;
+  BDD Regular(BDD f);
   BDD Not(BDD f);
-  BDD Implies(BDD f, BDD g);
   BDD Compose(BDD f, BDD g, BDD h);
-  BDD If(BDD f, BDD g, BDD h);
+  // BDD Intersects(BDD f, BDD g);
+  BDD Implies(BDD f, BDD g);
   BDD ITE(BDD f, BDD g, BDD h);
   BDD And(BDD f, BDD g);
+  // BDD And(IT begin, IT end); (using MultiwayAnd)
   BDD Nand(BDD f, BDD g);
   BDD Or(BDD f, BDD g);
+  // BDD Or(IT begin, IT end); (using MultiwayOr)
   BDD Nor(BDD f, BDD g);
   BDD Xor(BDD f, BDD g);
+  // BDD Xor(IT begin, IT end); (using MuliwayXor)
   BDD Xnor(BDD f, BDD g);
-  BDD Exists(BDD f);
-  // BDD RelProd(BDD f, BDD g);
-  BDD ForAll(BDD f);
-  BDD Cofactor(BDD f, BDD c);
-  BDD Between(BDD fMin, BDD fMax);
-  BDD Reduce(BDD f, BDD c);
-  BDD Regular(BDD f);
-  BDD SatisfySupport(BDD f);
-  double SatisfyingFraction(BDD f);
+  // container_t<BDD> PairwiseAnd(IT begin, IT end);
+  // container_t<BDD> PairwiseOr(IT begin, IT end);
+  // container_t<BDD> PairwiseXor(IT begin, IT end);
   BDD Satisfy(BDD f);
-  unsigned long Size(BDD f);
+  BDD SatisfySupport(BDD f);
+  // BDD Substitute(BDD f);
+  // BDD VarSubstitute(BDD f);
+  // BDD SwapVars(BDD f, BDD x, BDD y);
+  BDD Exists(BDD f);
+  BDD ForAll(BDD f);
+  // BDD RelProd(BDD f, BDD g);
+  BDD Cofactor(BDD f, BDD c);
+  BDD Reduce(BDD f, BDD c);
+  BDD Between(BDD fMin, BDD fMax);
+
+  // ---------------------------------------------------------------------------
+  // BDD Node Access / Traversal
+
+  // Cal_BddId_t IfIndex(BDD f) const;
+  // Cal_BddId_t IfId(BDD f) const;
+  BDD If(BDD f);
+  BDD Else(BDD f);
   BDD Then(BDD f);
+
+  // ---------------------------------------------------------------------------
+  // BDD Pipelining
+
+  // TODO: class Pipeline
+
+  // ---------------------------------------------------------------------------
+  // NOTE: These should never be exposed (the responsibility of BDD class)
+
+  // void Free();
+  // void UnFree();
 };
 
 // -----------------------------------------------------------------------------
@@ -179,8 +251,8 @@ public:
 
   // ---------------------------------------------------------------------------
   // Predicates
-  bool IsNull() const
-  { return Cal_BddIsBddNull(this->_bddManager, this->_bdd); }
+  bool IsEqual(const BDD &other) const
+  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
 
   bool IsOne() const
   { return Cal_BddIsBddOne(this->_bddManager, this->_bdd); }
@@ -188,17 +260,17 @@ public:
   bool IsZero() const
   { return Cal_BddIsBddZero(this->_bddManager, this->_bdd); }
 
+  bool IsNull() const
+  { return Cal_BddIsBddNull(this->_bddManager, this->_bdd); }
+
   bool IsConst() const
   { return Cal_BddIsBddConst(this->_bddManager, this->_bdd); }
 
   bool IsCube() const
   { return Cal_BddIsCube(this->_bddManager, this->_bdd); }
 
-  bool IsEqual(const BDD &other) const
-  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
-
   // ---------------------------------------------------------------------------
-  // Node traversal
+  // Node traversal and Information
   Cal_BddId_t Id() const
   { return Cal_BddGetIfId(this->_bddManager, this->_bdd); }
 
@@ -211,8 +283,15 @@ public:
   BDD Else() const
   { return BDD(this->_bddManager, Cal_BddElse(this->_bddManager, this->_bdd)); }
 
+  // Type BddType(BDD f);
+
   // ---------------------------------------------------------------------------
-  // Declaration of Operation overloads
+  // Operations
+
+  // TODO
+
+  // ---------------------------------------------------------------------------
+  // Operation Overloading
 
   BDD& operator= (const BDD &other)
   {
@@ -375,11 +454,8 @@ BDD Cal::Index(Cal_BddIndex_t idx) const
 { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
 
 // -----------------------------------------------------------------------------
-bool Cal::IsNull(BDD f) const
-{ return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
-
-bool Cal::IsNotNull(BDD f) const
-{ return Cal_BddIsBddNull(_bddManager, f._bdd) != 1; }
+bool Cal::IsEqual(BDD f, BDD g) const
+{ return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
 
 bool Cal::IsOne(BDD f) const
 { return Cal_BddIsBddOne(_bddManager, f._bdd) == 1; }
@@ -387,14 +463,14 @@ bool Cal::IsOne(BDD f) const
 bool Cal::IsZero(BDD f) const
 { return Cal_BddIsBddZero(_bddManager, f._bdd) == 1; }
 
+bool Cal::IsNull(BDD f) const
+{ return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
+
 bool Cal::IsConst(BDD f) const
 { return Cal_BddIsBddConst(_bddManager, f._bdd) == 1; }
 
 bool Cal::IsCube(BDD f) const
 { return Cal_BddIsCube(_bddManager, f._bdd) == 1; }
-
-bool Cal::IsEqual(BDD f, BDD g) const
-{ return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
 
 // -----------------------------------------------------------------------------
 BDD Cal::Else(BDD f)
@@ -468,4 +544,4 @@ unsigned long Cal::Size(BDD f)
 BDD Cal::Then(BDD f)
 { return BDD(_bddManager, Cal_BddThen(_bddManager, f._bdd)); }
 
-#endif // _CALOBJ
+#endif /* _CALOBJ */

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -17,6 +17,11 @@ class Cal {
   friend class BDD;
 
   // ---------------------------------------------------------------------------
+  // Types
+
+  // TODO:
+
+  // ---------------------------------------------------------------------------
   // Fields
 private:
   // TODO: std::shared_ptr for reference counting the Cal_BddManager
@@ -25,6 +30,7 @@ private:
   // ---------------------------------------------------------------------------
   // Constructors
 public:
+  // Reenable after adding NewVarLast to API
   Cal() = delete;
 
   Cal(unsigned int numVars) : _bddManager(Cal_BddManagerInit())
@@ -37,8 +43,10 @@ public:
     // TODO: Cal_BddManagerSetParameters
   }
 
-  // TODO: allow multiple copies to access Cal
+  // TODO: allow multiple copies to access Cal (requires reference counting)
   Cal(const Cal &o) = delete;
+
+  // TODO: move constructor
 
   ~Cal()
   {

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -34,9 +34,6 @@ public:
       Cal_BddManagerCreateNewVarLast(_bddManager);
     }
 
-    // Set reordering method to BF (cannot be set to DF - see Issue #5)
-    _bddManager->reorderMethod = CAL_REORDER_METHOD_BF;
-
     // TODO: Cal_BddManagerSetParameters
   }
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -285,8 +285,15 @@ public:
     WINDOW = CAL_REORDER_WINDOW
   };
 
-  void DynamicReordering(ReorderTechnique technique)
-  { Cal_BddDynamicReordering(_bddManager, technique); }
+  enum ReorderMethod {
+    BF = CAL_REORDER_METHOD_BF,
+    DF = CAL_REORDER_METHOD_DF
+  };
+
+  void DynamicReordering(ReorderTechnique technique, ReorderMethod method = ReorderMethod::DF)
+  {
+    Cal_BddDynamicReordering(_bddManager, technique, method);
+  }
 
   void Reorder()
   { Cal_BddReorder(_bddManager); }

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -227,7 +227,7 @@ public:
   {
     // Create variables
     for (Id_t i = 0; i < numVars; ++i){
-      Cal_BddManagerCreateNewVarLast(_bddManager);
+      Cal_BddManagerCreateNewVarLast(this->_bddManager);
     }
 
     // TODO: Cal_BddManagerSetParameters
@@ -240,41 +240,41 @@ public:
 
   ~Cal()
   {
-    Cal_BddManagerQuit(_bddManager);
+    Cal_BddManagerQuit(this->_bddManager);
   }
 
   // ---------------------------------------------------------------------------
   // Settings + Statistics
 
   unsigned long GetNumNodes()
-  { return Cal_BddManagerGetNumNodes(_bddManager); }
+  { return Cal_BddManagerGetNumNodes(this->_bddManager); }
 
   long Vars()
-  { return Cal_BddVars(_bddManager); }
+  { return Cal_BddVars(this->_bddManager); }
 
   bool Overflow()
-  { return Cal_BddOverflow(_bddManager); }
+  { return Cal_BddOverflow(this->_bddManager); }
 
   unsigned long TotalSize()
-  { return Cal_BddTotalSize(_bddManager); }
+  { return Cal_BddTotalSize(this->_bddManager); }
 
   void Stats(FILE* fp = stdout)
-  { Cal_BddStats(_bddManager, fp); }
+  { Cal_BddStats(this->_bddManager, fp); }
 
   // ---------------------------------------------------------------------------
   // Memory and Garbage Collection
 
   long NodeLimit(long newLimit)
-  { return Cal_BddNodeLimit(_bddManager, newLimit); }
+  { return Cal_BddNodeLimit(this->_bddManager, newLimit); }
 
   void SetGCMode(bool enableGC)
-  { Cal_BddSetGCMode(_bddManager, enableGC); }
+  { Cal_BddSetGCMode(this->_bddManager, enableGC); }
 
   void SetGCLimit()
-  { Cal_BddManagerSetGCLimit(_bddManager); }
+  { Cal_BddManagerSetGCLimit(this->_bddManager); }
 
   void GC()
-  { Cal_BddManagerGC(_bddManager); }
+  { Cal_BddManagerGC(this->_bddManager); }
 
   // ---------------------------------------------------------------------------
   // Reordering
@@ -357,19 +357,19 @@ public:
   // ---------------------------------------------------------------------------
   // BDD Constructors
   BDD Null() const
-  { return BDD(_bddManager, Cal_BddNull(_bddManager)); }
+  { return BDD(this->_bddManager, Cal_BddNull(this->_bddManager)); }
 
   BDD One() const
-  { return BDD(_bddManager, Cal_BddOne(_bddManager)); }
+  { return BDD(this->_bddManager, Cal_BddOne(this->_bddManager)); }
 
   BDD Zero() const
-  { return BDD(_bddManager, Cal_BddZero(_bddManager)); }
+  { return BDD(this->_bddManager, Cal_BddZero(this->_bddManager)); }
 
   BDD Id(Id_t id) const
-  { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, id)); }
+  { return BDD(this->_bddManager, Cal_BddManagerGetVarWithId(this->_bddManager, id)); }
 
   BDD Index(Index_t idx) const
-  { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
+  { return BDD(this->_bddManager, Cal_BddManagerGetVarWithId(this->_bddManager, idx)); }
 
   // BDD CreateNewVarFirst();
   // BDD CreateNewVarFirst();
@@ -403,7 +403,7 @@ public:
   // ---------------------------------------------------------------------------
   // BDD Information
   double SatisfyingFraction(BDD f)
-  { return Cal_BddSatisfyingFraction(_bddManager, f._bdd); }
+  { return Cal_BddSatisfyingFraction(this->_bddManager, f._bdd); }
 
   unsigned long Size(BDD f)
   { return Cal_BddSize(_bddManager, f._bdd, 0); }
@@ -418,55 +418,55 @@ public:
   // BDD Identity(BDD f) const
 
   BDD Regular(BDD f)
-  { return BDD(_bddManager, Cal_BddGetRegular(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddGetRegular(this->_bddManager, f._bdd)); }
 
   BDD Not(BDD f)
-  { return BDD(_bddManager, Cal_BddNot(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddNot(this->_bddManager, f._bdd)); }
 
   BDD Compose(BDD f, BDD g, BDD h)
-  { return BDD(_bddManager, Cal_BddCompose(_bddManager, f._bdd, g._bdd, h._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddCompose(this->_bddManager, f._bdd, g._bdd, h._bdd)); }
 
   // BDD Intersects(BDD f, BDD g)
 
   BDD Implies(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddImplies(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddImplies(this->_bddManager, f._bdd, g._bdd)); }
 
   BDD ITE(BDD f, BDD g, BDD h)
-  { return BDD(_bddManager, Cal_BddITE(_bddManager, f._bdd, g._bdd, h._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddITE(this->_bddManager, f._bdd, g._bdd, h._bdd)); }
 
   BDD And(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddAnd(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddAnd(this->_bddManager, f._bdd, g._bdd)); }
 
   // BDD And(IT begin, IT end); (using MultiwayAnd)
 
   BDD Nand(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddNand(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddNand(this->_bddManager, f._bdd, g._bdd)); }
 
   BDD Or(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddOr(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddOr(this->_bddManager, f._bdd, g._bdd)); }
 
   // BDD Or(IT begin, IT end); (using MultiwayOr)
 
   BDD Nor(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddNor(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddNor(this->_bddManager, f._bdd, g._bdd)); }
 
   BDD Xor(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddXor(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddXor(this->_bddManager, f._bdd, g._bdd)); }
 
   // BDD Xor(IT begin, IT end); (using MuliwayXor)
 
   BDD Xnor(BDD f, BDD g)
-  { return BDD(_bddManager, Cal_BddXnor(_bddManager, f._bdd, g._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddXnor(this->_bddManager, f._bdd, g._bdd)); }
 
   // container_t<BDD> PairwiseAnd(IT begin, IT end)
   // container_t<BDD> PairwiseOr(IT begin, IT end)
   // container_t<BDD> PairwiseXor(IT begin, IT end)
 
   BDD Satisfy(BDD f)
-  { return BDD(_bddManager, Cal_BddSatisfy(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddSatisfy(this->_bddManager, f._bdd)); }
 
   BDD SatisfySupport(BDD f)
-  { return BDD(_bddManager, Cal_BddSatisfySupport(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddSatisfySupport(this->_bddManager, f._bdd)); }
 
   // BDD Substitute(BDD f)
 
@@ -475,27 +475,27 @@ public:
   // BDD SwapVars(BDD f, BDD x, BDD y)
 
   BDD Exists(BDD f)
-  { return BDD(_bddManager, Cal_BddExists(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddExists(this->_bddManager, f._bdd)); }
 
   BDD ForAll(BDD f)
-  { return BDD(_bddManager, Cal_BddForAll(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddForAll(this->_bddManager, f._bdd)); }
 
   // BDD RelProd(BDD f, BDD g)
 
   BDD Cofactor(BDD f, BDD c)
-  { return BDD(_bddManager, Cal_BddCofactor(_bddManager, f._bdd, c._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddCofactor(this->_bddManager, f._bdd, c._bdd)); }
 
   BDD Reduce(BDD f, BDD c)
-  { return BDD(_bddManager, Cal_BddReduce(_bddManager, f._bdd, c._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddReduce(this->_bddManager, f._bdd, c._bdd)); }
 
   BDD Between(BDD fMin, BDD fMax)
-  { return BDD(_bddManager, Cal_BddBetween(_bddManager, fMin._bdd, fMax._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddBetween(this->_bddManager, fMin._bdd, fMax._bdd)); }
 
   // ---------------------------------------------------------------------------
   // BDD Node Access / Traversal
 
   BDD If(BDD f)
-  { return BDD(_bddManager, Cal_BddIf(_bddManager, f._bdd)); }
+  { return BDD(this->_bddManager, Cal_BddIf(this->_bddManager, f._bdd)); }
 
   // Id_t IfId(BDD f) const
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -16,6 +16,10 @@ class Cal;
 class BDD {
   friend Cal;
 
+public:
+  using Id_t = Cal_BddId_t;
+  using Index_t = Cal_BddIndex_t;
+
 private:
   Cal_BddManager _bddManager;
   Cal_Bdd _bdd;
@@ -75,10 +79,10 @@ public:
 
   // ---------------------------------------------------------------------------
   // Node traversal and Information
-  Cal_BddId_t Id() const
+  Id_t Id() const
   { return Cal_BddGetIfId(this->_bddManager, this->_bdd); }
 
-  Cal_BddIndex_t Index() const
+  Index_t Index() const
   { return Cal_BddGetIfIndex(this->_bddManager, this->_bdd); }
 
   BDD Then() const
@@ -201,6 +205,9 @@ class Cal {
 
   // ---------------------------------------------------------------------------
   // Types
+  using Bdd_t = BDD;
+  using Id_t = BDD::Id_t;
+  using Index_t = BDD::Index_t;
 
   // TODO:
 
@@ -219,7 +226,7 @@ public:
   Cal(unsigned int numVars) : _bddManager(Cal_BddManagerInit())
   {
     // Create variables
-    for (Cal_BddId_t i = 0; i < numVars; ++i){
+    for (Id_t i = 0; i < numVars; ++i){
       Cal_BddManagerCreateNewVarLast(_bddManager);
     }
 
@@ -351,18 +358,18 @@ public:
   BDD Zero() const
   { return BDD(_bddManager, Cal_BddZero(_bddManager)); }
 
-  BDD Id(Cal_BddId_t id) const
+  BDD Id(Id_t id) const
   { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, id)); }
 
-  BDD Index(Cal_BddIndex_t idx) const
+  BDD Index(Index_t idx) const
   { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
 
   // BDD CreateNewVarFirst();
   // BDD CreateNewVarFirst();
   // BDD CreateNewVarBefore(BDD x);
   // BDD CreateNewVarAfter(BDD x);
-  // BDD CreateNewVarWithIndex(BDD x, Cal_BddIndex_t index);
-  // BDD CreateNewVarWithId(Cal_BddId_t id);
+  // BDD CreateNewVarWithIndex(BDD x, Index_t index);
+  // BDD CreateNewVarWithId(Id_t id);
 
   // ---------------------------------------------------------------------------
   // BDD Predicates
@@ -483,9 +490,9 @@ public:
   BDD If(BDD f)
   { return BDD(_bddManager, Cal_BddIf(_bddManager, f._bdd)); }
 
-  // Cal_BddId_t IfIndex(BDD f) const
+  // Id_t IfId(BDD f) const
 
-  // Cal_BddId_t IfId(BDD f) const
+  // Index_t IfIndex(BDD f) const
 
   BDD Then(BDD f)
   { return f.Then(); }

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -7,205 +7,9 @@ extern "C" {
 }
 
 // -----------------------------------------------------------------------------
-// Type declarations
+// Forward Declarations
 class BDD;
 class Cal;
-
-// -----------------------------------------------------------------------------
-// BDD Manager
-class Cal {
-  friend class BDD;
-
-  // ---------------------------------------------------------------------------
-  // Types
-
-  // TODO:
-
-  // ---------------------------------------------------------------------------
-  // Fields
-private:
-  // TODO: std::shared_ptr for reference counting the Cal_BddManager
-  Cal_BddManager _bddManager;
-
-  // ---------------------------------------------------------------------------
-  // Constructors
-public:
-  // Reenable after adding NewVarLast to API
-  Cal() = delete;
-
-  Cal(unsigned int numVars) : _bddManager(Cal_BddManagerInit())
-  {
-    // Create variables
-    for (Cal_BddId_t i = 0; i < numVars; ++i){
-      Cal_BddManagerCreateNewVarLast(_bddManager);
-    }
-
-    // TODO: Cal_BddManagerSetParameters
-  }
-
-  // TODO: allow multiple copies to access Cal (requires reference counting)
-  Cal(const Cal &o) = delete;
-
-  // TODO: move constructor
-
-  ~Cal()
-  {
-    Cal_BddManagerQuit(_bddManager);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Settings + Statistics
-
-  unsigned long GetNumNodes()
-  { return Cal_BddManagerGetNumNodes(_bddManager); }
-
-  long Vars()
-  { return Cal_BddVars(_bddManager); }
-
-  bool Overflow()
-  { return Cal_BddOverflow(_bddManager); }
-
-  unsigned long TotalSize()
-  { return Cal_BddTotalSize(_bddManager); }
-
-  void Stats(FILE* fp = stdout)
-  { Cal_BddStats(_bddManager, fp); }
-
-  // ---------------------------------------------------------------------------
-  // Memory and Garbage Collection
-
-  long NodeLimit(long newLimit)
-  { return Cal_BddNodeLimit(_bddManager, newLimit); }
-
-  void SetGCMode(bool enableGC)
-  { Cal_BddSetGCMode(_bddManager, enableGC); }
-
-  void SetGCLimit()
-  { Cal_BddManagerSetGCLimit(_bddManager); }
-
-  void GC()
-  { Cal_BddManagerGC(_bddManager); }
-
-  // ---------------------------------------------------------------------------
-  // Reordering
-
-  enum ReorderTechnique {
-    NONE = CAL_REORDER_NONE,
-    SIFT = CAL_REORDER_SIFT,
-    WINDOW = CAL_REORDER_WINDOW
-  };
-
-  void DynamicReordering(ReorderTechnique technique)
-  { Cal_BddDynamicReordering(_bddManager, technique); }
-
-  void Reorder()
-  { Cal_BddReorder(_bddManager); }
-
-  // SwapVars(BDD x, BDD y);
-
-  // ---------------------------------------------------------------------------
-  // Declaration of Association List
-
-  template<typename BDD_IT>
-  int AssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false);
-  void AssociationQuit(int i);
-  int AssociationSetCurrent(int i);
-  // void TempAssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false);
-  // void TempAssociationAugment(BDD_IT begin, const BDD_IT end, const bool pairs = false);
-  // void TempAssociationQuit();
-
-  // ---------------------------------------------------------------------------
-  // Save / Load BDDs
-
-  // BDD UndumpBdd(IT vars_begin, IT vars_end, FILE *f, int &error)
-  // BDD DumpBdd(BDD f, IT vars_begin, IT vars_end, FILE *f, int &error)
-
-  // ---------------------------------------------------------------------------
-  // BDD Constructors
-  BDD Null() const;
-  BDD One() const;
-  BDD Zero() const;
-  BDD Id(Cal_BddId_t id) const;
-  BDD Index(Cal_BddIndex_t idx) const;
-
-  // BDD CreateNewVarFirst();
-  // BDD CreateNewVarFirst();
-  // BDD CreateNewVarBefore(BDD x);
-  // BDD CreateNewVarAfter(BDD x);
-  // BDD CreateNewVarWithIndex(BDD x, Cal_BddIndex_t index);
-  // BDD CreateNewVarWithId(Cal_BddId_t id);
-
-  // ---------------------------------------------------------------------------
-  // BDD Predicates
-  bool IsNull(BDD f) const;
-  bool IsOne(BDD f) const;
-  bool IsZero(BDD f) const;
-  bool IsConst(BDD f) const;
-  bool IsCube(BDD f) const;
-  bool IsEqual(BDD f, BDD g) const;
-  // bool DependsOn(BDD f, BDD vars) const;
-
-  // ---------------------------------------------------------------------------
-  // BDD Information
-  double SatisfyingFraction(BDD f);
-  unsigned long Size(BDD f);
-  // unsigned long Size(IT begin, IT end, bool negout); (using MultipleSize)
-  // container_t<BDD> Support(BDD f);
-
-  // ---------------------------------------------------------------------------
-  // Manipulation
-
-  // BDD Identity(BDD f) const;
-  BDD Regular(BDD f);
-  BDD Not(BDD f);
-  BDD Compose(BDD f, BDD g, BDD h);
-  // BDD Intersects(BDD f, BDD g);
-  BDD Implies(BDD f, BDD g);
-  BDD ITE(BDD f, BDD g, BDD h);
-  BDD And(BDD f, BDD g);
-  // BDD And(IT begin, IT end); (using MultiwayAnd)
-  BDD Nand(BDD f, BDD g);
-  BDD Or(BDD f, BDD g);
-  // BDD Or(IT begin, IT end); (using MultiwayOr)
-  BDD Nor(BDD f, BDD g);
-  BDD Xor(BDD f, BDD g);
-  // BDD Xor(IT begin, IT end); (using MuliwayXor)
-  BDD Xnor(BDD f, BDD g);
-  // container_t<BDD> PairwiseAnd(IT begin, IT end);
-  // container_t<BDD> PairwiseOr(IT begin, IT end);
-  // container_t<BDD> PairwiseXor(IT begin, IT end);
-  BDD Satisfy(BDD f);
-  BDD SatisfySupport(BDD f);
-  // BDD Substitute(BDD f);
-  // BDD VarSubstitute(BDD f);
-  // BDD SwapVars(BDD f, BDD x, BDD y);
-  BDD Exists(BDD f);
-  BDD ForAll(BDD f);
-  // BDD RelProd(BDD f, BDD g);
-  BDD Cofactor(BDD f, BDD c);
-  BDD Reduce(BDD f, BDD c);
-  BDD Between(BDD fMin, BDD fMax);
-
-  // ---------------------------------------------------------------------------
-  // BDD Node Access / Traversal
-
-  // Cal_BddId_t IfIndex(BDD f) const;
-  // Cal_BddId_t IfId(BDD f) const;
-  BDD If(BDD f);
-  BDD Else(BDD f);
-  BDD Then(BDD f);
-
-  // ---------------------------------------------------------------------------
-  // BDD Pipelining
-
-  // TODO: class Pipeline
-
-  // ---------------------------------------------------------------------------
-  // NOTE: These should never be exposed (the responsibility of BDD class)
-
-  // void Free();
-  // void UnFree();
-};
 
 // -----------------------------------------------------------------------------
 // BDD Class
@@ -391,157 +195,312 @@ public:
 };
 
 // -----------------------------------------------------------------------------
-// Cal member functions
-//
-// TODO: Sanity check on wrappers
-//  - Use the same manager? Otherwise, throw 'not-same-manager' error.
-//  - inner Cal_Bdd is not NULL. Otherwise, throw 'out-of-memory' error.
+// BDD Manager
+class Cal {
+  friend BDD;
 
-// -----------------------------------------------------------------------------
-template<typename BDD_IT>
-int Cal::AssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs)
-{
-  std::vector<Cal_Bdd> c_arg;
-  c_arg.reserve(std::distance(begin, end));
+  // ---------------------------------------------------------------------------
+  // Types
 
-  if constexpr(std::is_same_v<typename BDD_IT::value_type, BDD>) {
-    while (begin != end) {
-      const Cal_Bdd c_bdd = (begin++)->_bdd;
-      Cal_BddUnFree(_bddManager, c_bdd);
-      c_arg.push_back(c_bdd);
+  // TODO:
+
+  // ---------------------------------------------------------------------------
+  // Fields
+private:
+  // TODO: std::shared_ptr for reference counting the Cal_BddManager
+  Cal_BddManager _bddManager;
+
+  // ---------------------------------------------------------------------------
+  // Constructors
+public:
+  // Reenable after adding NewVarLast to API
+  Cal() = delete;
+
+  Cal(unsigned int numVars) : _bddManager(Cal_BddManagerInit())
+  {
+    // Create variables
+    for (Cal_BddId_t i = 0; i < numVars; ++i){
+      Cal_BddManagerCreateNewVarLast(_bddManager);
     }
-  } else if constexpr (std::is_same_v<typename BDD_IT::value_type, int>) {
-    while (begin != end) {
-      c_arg.push_back(Cal_BddManagerGetVarWithId(_bddManager, *(begin++)));
-    }
-  } else {
-    static_assert(false, "This type cannot be handled by Cal");
+
+    // TODO: Cal_BddManagerSetParameters
   }
 
-  const BDD end_marker = Null();
-  c_arg.push_back(end_marker._bdd);
+  // TODO: allow multiple copies to access Cal (requires reference counting)
+  Cal(const Cal &o) = delete;
 
-  const int res = Cal_AssociationInit(_bddManager, c_arg.data(), pairs);
+  // TODO: move constructor
 
-  for (const Cal_Bdd& arg : c_arg) {
-    if (Cal_BddIsBddNull(_bddManager, arg) == 0)
-      Cal_BddFree(_bddManager, arg);
+  ~Cal()
+  {
+    Cal_BddManagerQuit(_bddManager);
   }
 
-  return res;
-}
+  // ---------------------------------------------------------------------------
+  // Settings + Statistics
 
-void Cal::AssociationQuit(int i)
-{ Cal_AssociationQuit(_bddManager, i); }
+  unsigned long GetNumNodes()
+  { return Cal_BddManagerGetNumNodes(_bddManager); }
 
-int Cal::AssociationSetCurrent(int i)
-{ return Cal_AssociationSetCurrent(_bddManager, i); }
+  long Vars()
+  { return Cal_BddVars(_bddManager); }
 
-// -----------------------------------------------------------------------------
-BDD Cal::Null() const
-{ return BDD(_bddManager, Cal_BddNull(_bddManager)); }
+  bool Overflow()
+  { return Cal_BddOverflow(_bddManager); }
 
-BDD Cal::One() const
-{ return BDD(_bddManager, Cal_BddOne(_bddManager)); }
+  unsigned long TotalSize()
+  { return Cal_BddTotalSize(_bddManager); }
 
-BDD Cal::Zero() const
-{ return BDD(_bddManager, Cal_BddZero(_bddManager)); }
+  void Stats(FILE* fp = stdout)
+  { Cal_BddStats(_bddManager, fp); }
 
-BDD Cal::Id(Cal_BddId_t id) const
-{ return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, id)); }
+  // ---------------------------------------------------------------------------
+  // Memory and Garbage Collection
 
-BDD Cal::Index(Cal_BddIndex_t idx) const
-{ return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
+  long NodeLimit(long newLimit)
+  { return Cal_BddNodeLimit(_bddManager, newLimit); }
 
-// -----------------------------------------------------------------------------
-bool Cal::IsEqual(BDD f, BDD g) const
-{ return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
+  void SetGCMode(bool enableGC)
+  { Cal_BddSetGCMode(_bddManager, enableGC); }
 
-bool Cal::IsOne(BDD f) const
-{ return Cal_BddIsBddOne(_bddManager, f._bdd) == 1; }
+  void SetGCLimit()
+  { Cal_BddManagerSetGCLimit(_bddManager); }
 
-bool Cal::IsZero(BDD f) const
-{ return Cal_BddIsBddZero(_bddManager, f._bdd) == 1; }
+  void GC()
+  { Cal_BddManagerGC(_bddManager); }
 
-bool Cal::IsNull(BDD f) const
-{ return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
+  // ---------------------------------------------------------------------------
+  // Reordering
 
-bool Cal::IsConst(BDD f) const
-{ return Cal_BddIsBddConst(_bddManager, f._bdd) == 1; }
+  enum ReorderTechnique {
+    NONE = CAL_REORDER_NONE,
+    SIFT = CAL_REORDER_SIFT,
+    WINDOW = CAL_REORDER_WINDOW
+  };
 
-bool Cal::IsCube(BDD f) const
-{ return Cal_BddIsCube(_bddManager, f._bdd) == 1; }
+  void DynamicReordering(ReorderTechnique technique)
+  { Cal_BddDynamicReordering(_bddManager, technique); }
 
-// -----------------------------------------------------------------------------
-BDD Cal::Else(BDD f)
-{ return BDD(_bddManager, Cal_BddElse(_bddManager, f._bdd)); }
+  void Reorder()
+  { Cal_BddReorder(_bddManager); }
 
-BDD Cal::Not(BDD f)
-{ return BDD(_bddManager, Cal_BddNot(_bddManager, f._bdd)); }
+  // SwapVars(BDD x, BDD y);
 
-BDD Cal::Implies(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddImplies(_bddManager, f._bdd, g._bdd)); }
+  // ---------------------------------------------------------------------------
+  // Declaration of Association List
 
-BDD Cal::Compose(BDD f, BDD g, BDD h)
-{ return BDD(_bddManager, Cal_BddCompose(_bddManager, f._bdd, g._bdd, h._bdd)); }
+  template<typename BDD_IT>
+  int AssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false)
+  {
+    std::vector<Cal_Bdd> c_arg;
+    c_arg.reserve(std::distance(begin, end));
 
-BDD Cal::If(BDD f)
-{ return BDD(_bddManager, Cal_BddIf(_bddManager, f._bdd)); }
+    if constexpr(std::is_same_v<typename BDD_IT::value_type, BDD>) {
+      while (begin != end) {
+        const Cal_Bdd c_bdd = (begin++)->_bdd;
+        Cal_BddUnFree(_bddManager, c_bdd);
+        c_arg.push_back(c_bdd);
+      }
+    } else if constexpr (std::is_same_v<typename BDD_IT::value_type, int>) {
+      while (begin != end) {
+        c_arg.push_back(Cal_BddManagerGetVarWithId(_bddManager, *(begin++)));
+      }
+    } else {
+      static_assert(false, "This type cannot be handled by Cal");
+    }
 
-BDD Cal::ITE(BDD f, BDD g, BDD h)
-{ return BDD(_bddManager, Cal_BddITE(_bddManager, f._bdd, g._bdd, h._bdd)); }
+    const BDD end_marker = Null();
+    c_arg.push_back(end_marker._bdd);
 
-BDD Cal::And(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddAnd(_bddManager, f._bdd, g._bdd)); }
+    const int res = Cal_AssociationInit(_bddManager, c_arg.data(), pairs);
 
-BDD Cal::Nand(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddNand(_bddManager, f._bdd, g._bdd)); }
+    for (const Cal_Bdd& arg : c_arg) {
+      if (Cal_BddIsBddNull(_bddManager, arg) == 0)
+        Cal_BddFree(_bddManager, arg);
+    }
 
-BDD Cal::Or(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddOr(_bddManager, f._bdd, g._bdd)); }
+    return res;
+  }
 
-BDD Cal::Nor(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddNor(_bddManager, f._bdd, g._bdd)); }
+  void AssociationQuit(int i)
+  { Cal_AssociationQuit(_bddManager, i); }
 
-BDD Cal::Xor(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddXor(_bddManager, f._bdd, g._bdd)); }
+  int AssociationSetCurrent(int i)
+  { return Cal_AssociationSetCurrent(_bddManager, i); }
 
-BDD Cal::Xnor(BDD f, BDD g)
-{ return BDD(_bddManager, Cal_BddXnor(_bddManager, f._bdd, g._bdd)); }
+  // void TempAssociationInit(BDD_IT begin, const BDD_IT end, const bool pairs = false)
 
-BDD Cal::Exists(BDD f)
-{ return BDD(_bddManager, Cal_BddExists(_bddManager, f._bdd)); }
+  // void TempAssociationAugment(BDD_IT begin, const BDD_IT end, const bool pairs = false)
 
-// BDD Cal::RelProd(BDD f, BDD g) { TODO }
+  // void TempAssociationQuit()
 
-BDD Cal::ForAll(BDD f)
-{ return BDD(_bddManager, Cal_BddForAll(_bddManager, f._bdd)); }
+  // ---------------------------------------------------------------------------
+  // Save / Load BDDs
 
-BDD Cal::Cofactor(BDD f, BDD c)
-{ return BDD(_bddManager, Cal_BddCofactor(_bddManager, f._bdd, c._bdd)); }
+  // BDD UndumpBdd(IT vars_begin, IT vars_end, FILE *f, int &error)
+  // BDD DumpBdd(BDD f, IT vars_begin, IT vars_end, FILE *f, int &error)
 
-BDD Cal::Between(BDD fMin, BDD fMax)
-{ return BDD(_bddManager, Cal_BddCofactor(_bddManager, fMin._bdd, fMax._bdd)); }
+  // ---------------------------------------------------------------------------
+  // BDD Constructors
+  BDD Null() const
+  { return BDD(_bddManager, Cal_BddNull(_bddManager)); }
 
-BDD Cal::Reduce(BDD f, BDD c)
-{ return BDD(_bddManager, Cal_BddReduce(_bddManager, f._bdd, c._bdd)); }
+  BDD One() const
+  { return BDD(_bddManager, Cal_BddOne(_bddManager)); }
 
-BDD Cal::Regular(BDD f)
-{ return BDD(_bddManager, Cal_BddGetRegular(_bddManager, f._bdd)); }
+  BDD Zero() const
+  { return BDD(_bddManager, Cal_BddZero(_bddManager)); }
 
-BDD Cal::SatisfySupport(BDD f)
-{ return BDD(_bddManager, Cal_BddSatisfySupport(_bddManager, f._bdd)); }
+  BDD Id(Cal_BddId_t id) const
+  { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, id)); }
 
-double Cal::SatisfyingFraction(BDD f)
-{ return Cal_BddSatisfyingFraction(_bddManager, f._bdd); }
+  BDD Index(Cal_BddIndex_t idx) const
+  { return BDD(_bddManager, Cal_BddManagerGetVarWithId(_bddManager, idx)); }
 
-BDD Cal::Satisfy(BDD f)
-{ return BDD(_bddManager, Cal_BddSatisfy(_bddManager, f._bdd)); }
+  // BDD CreateNewVarFirst();
+  // BDD CreateNewVarFirst();
+  // BDD CreateNewVarBefore(BDD x);
+  // BDD CreateNewVarAfter(BDD x);
+  // BDD CreateNewVarWithIndex(BDD x, Cal_BddIndex_t index);
+  // BDD CreateNewVarWithId(Cal_BddId_t id);
 
-unsigned long Cal::Size(BDD f)
-{ return Cal_BddSize(_bddManager, f._bdd, 0); }
+  // ---------------------------------------------------------------------------
+  // BDD Predicates
+  bool IsNull(BDD f) const
+  { return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
 
-BDD Cal::Then(BDD f)
-{ return BDD(_bddManager, Cal_BddThen(_bddManager, f._bdd)); }
+  bool IsOne(BDD f) const
+  { return Cal_BddIsBddOne(_bddManager, f._bdd) == 1; }
+
+  bool IsZero(BDD f) const
+  { return Cal_BddIsBddZero(_bddManager, f._bdd) == 1; }
+
+  bool IsConst(BDD f) const
+  { return Cal_BddIsBddConst(_bddManager, f._bdd) == 1; }
+
+  bool IsCube(BDD f) const
+  { return Cal_BddIsCube(_bddManager, f._bdd) == 1; }
+
+  bool IsEqual(BDD f, BDD g) const
+  { return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
+
+  // bool DependsOn(BDD f, BDD vars) const;
+
+  // ---------------------------------------------------------------------------
+  // BDD Information
+  double SatisfyingFraction(BDD f)
+  { return Cal_BddSatisfyingFraction(_bddManager, f._bdd); }
+
+  unsigned long Size(BDD f)
+  { return Cal_BddSize(_bddManager, f._bdd, 0); }
+
+  // unsigned long Size(IT begin, IT end, bool negout); (using MultipleSize)
+
+  // container_t<BDD> Support(BDD f);
+
+  // ---------------------------------------------------------------------------
+  // Manipulation
+
+  // BDD Identity(BDD f) const
+
+  BDD Regular(BDD f)
+  { return BDD(_bddManager, Cal_BddGetRegular(_bddManager, f._bdd)); }
+
+  BDD Not(BDD f)
+  { return BDD(_bddManager, Cal_BddNot(_bddManager, f._bdd)); }
+
+  BDD Compose(BDD f, BDD g, BDD h)
+  { return BDD(_bddManager, Cal_BddCompose(_bddManager, f._bdd, g._bdd, h._bdd)); }
+
+  // BDD Intersects(BDD f, BDD g)
+
+  BDD Implies(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddImplies(_bddManager, f._bdd, g._bdd)); }
+
+  BDD ITE(BDD f, BDD g, BDD h)
+  { return BDD(_bddManager, Cal_BddITE(_bddManager, f._bdd, g._bdd, h._bdd)); }
+
+  BDD And(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddAnd(_bddManager, f._bdd, g._bdd)); }
+
+  // BDD And(IT begin, IT end); (using MultiwayAnd)
+
+  BDD Nand(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddNand(_bddManager, f._bdd, g._bdd)); }
+
+  BDD Or(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddOr(_bddManager, f._bdd, g._bdd)); }
+
+  // BDD Or(IT begin, IT end); (using MultiwayOr)
+
+  BDD Nor(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddNor(_bddManager, f._bdd, g._bdd)); }
+
+  BDD Xor(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddXor(_bddManager, f._bdd, g._bdd)); }
+
+  // BDD Xor(IT begin, IT end); (using MuliwayXor)
+
+  BDD Xnor(BDD f, BDD g)
+  { return BDD(_bddManager, Cal_BddXnor(_bddManager, f._bdd, g._bdd)); }
+
+  // container_t<BDD> PairwiseAnd(IT begin, IT end)
+  // container_t<BDD> PairwiseOr(IT begin, IT end)
+  // container_t<BDD> PairwiseXor(IT begin, IT end)
+
+  BDD Satisfy(BDD f)
+  { return BDD(_bddManager, Cal_BddSatisfy(_bddManager, f._bdd)); }
+
+  BDD SatisfySupport(BDD f)
+  { return BDD(_bddManager, Cal_BddSatisfySupport(_bddManager, f._bdd)); }
+
+  // BDD Substitute(BDD f)
+
+  // BDD VarSubstitute(BDD f)
+
+  // BDD SwapVars(BDD f, BDD x, BDD y)
+
+  BDD Exists(BDD f)
+  { return BDD(_bddManager, Cal_BddExists(_bddManager, f._bdd)); }
+
+  BDD ForAll(BDD f)
+  { return BDD(_bddManager, Cal_BddForAll(_bddManager, f._bdd)); }
+
+  // BDD RelProd(BDD f, BDD g)
+
+  BDD Cofactor(BDD f, BDD c)
+  { return BDD(_bddManager, Cal_BddCofactor(_bddManager, f._bdd, c._bdd)); }
+
+  BDD Reduce(BDD f, BDD c)
+  { return BDD(_bddManager, Cal_BddReduce(_bddManager, f._bdd, c._bdd)); }
+
+  BDD Between(BDD fMin, BDD fMax)
+  { return BDD(_bddManager, Cal_BddBetween(_bddManager, fMin._bdd, fMax._bdd)); }
+
+  // ---------------------------------------------------------------------------
+  // BDD Node Access / Traversal
+
+  // Cal_BddId_t IfIndex(BDD f) const;
+  // Cal_BddId_t IfId(BDD f) const;
+  BDD If(BDD f)
+  { return BDD(_bddManager, Cal_BddIf(_bddManager, f._bdd)); }
+
+  BDD Else(BDD f)
+  { return BDD(_bddManager, Cal_BddElse(_bddManager, f._bdd)); }
+
+  BDD Then(BDD f)
+  { return BDD(_bddManager, Cal_BddThen(_bddManager, f._bdd)); }
+
+  // ---------------------------------------------------------------------------
+  // BDD Pipelining
+
+  // TODO: class Pipeline
+
+  // ---------------------------------------------------------------------------
+  // NOTE: These should never be exposed (hidden inside of the BDD class)
+
+  // void Free();
+  // void UnFree();
+};
 
 #endif /* _CALOBJ */

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -55,9 +55,6 @@ public:
 
   // ---------------------------------------------------------------------------
   // Predicates
-  bool IsEqual(const BDD &other) const
-  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
-
   bool IsOne() const
   { return Cal_BddIsBddOne(this->_bddManager, this->_bdd); }
 
@@ -72,6 +69,9 @@ public:
 
   bool IsCube() const
   { return Cal_BddIsCube(this->_bddManager, this->_bdd); }
+
+  bool IsEqualTo(const BDD &other) const
+  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
 
   // ---------------------------------------------------------------------------
   // Node traversal and Information

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -122,7 +122,7 @@ public:
   }
 
   bool operator== (const BDD &other) const
-  { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
+  { return IsEqualTo(other); }
 
   bool  operator!= (const BDD &other) const
   { return !(*this == other); }
@@ -367,22 +367,22 @@ public:
   // ---------------------------------------------------------------------------
   // BDD Predicates
   bool IsNull(BDD f) const
-  { return Cal_BddIsBddNull(_bddManager, f._bdd) == 1; }
+  { return f.IsNull(); }
 
   bool IsOne(BDD f) const
-  { return Cal_BddIsBddOne(_bddManager, f._bdd) == 1; }
+  { return f.IsOne(); }
 
   bool IsZero(BDD f) const
-  { return Cal_BddIsBddZero(_bddManager, f._bdd) == 1; }
+  { return f.IsZero(); }
 
   bool IsConst(BDD f) const
-  { return Cal_BddIsBddConst(_bddManager, f._bdd) == 1; }
+  { return f.IsConst(); }
 
   bool IsCube(BDD f) const
-  { return Cal_BddIsCube(_bddManager, f._bdd) == 1; }
+  { return f.IsCube(); }
 
   bool IsEqual(BDD f, BDD g) const
-  { return Cal_BddIsEqual(_bddManager, f._bdd, g._bdd) == 1; }
+  { return f.IsEqualTo(g); }
 
   // bool DependsOn(BDD f, BDD vars) const;
 
@@ -480,16 +480,18 @@ public:
   // ---------------------------------------------------------------------------
   // BDD Node Access / Traversal
 
-  // Cal_BddId_t IfIndex(BDD f) const;
-  // Cal_BddId_t IfId(BDD f) const;
   BDD If(BDD f)
   { return BDD(_bddManager, Cal_BddIf(_bddManager, f._bdd)); }
 
-  BDD Else(BDD f)
-  { return BDD(_bddManager, Cal_BddElse(_bddManager, f._bdd)); }
+  // Cal_BddId_t IfIndex(BDD f) const
+
+  // Cal_BddId_t IfId(BDD f) const
 
   BDD Then(BDD f)
-  { return BDD(_bddManager, Cal_BddThen(_bddManager, f._bdd)); }
+  { return f.Then(); }
+
+  BDD Else(BDD f)
+  { return f.Else(); }
 
   // ---------------------------------------------------------------------------
   // BDD Pipelining

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -236,14 +236,16 @@ private:
   // ---------------------------------------------------------------------------
   // Constructors
 public:
-  // Reenable after adding NewVarLast to API
-  Cal() = delete;
+  Cal()
+    :_bddManager(Cal_BddManagerInit())
+  { }
 
-  Cal(unsigned int numVars) : _bddManager(Cal_BddManagerInit())
+  Cal(unsigned int numVars)
+    : Cal()
   {
     // Create variables
-    for (Id_t i = 0; i < numVars; ++i){
-      Cal_BddManagerCreateNewVarLast(this->_bddManager);
+    for (Id_t i = 0; i < numVars; ++i) {
+      this->CreateNewVarLast();
     }
 
     // TODO: Cal_BddManagerSetParameters
@@ -387,12 +389,17 @@ public:
   BDD Index(Index_t idx) const
   { return BDD(this->_bddManager, Cal_BddManagerGetVarWithId(this->_bddManager, idx)); }
 
-  // BDD CreateNewVarFirst();
-  // BDD CreateNewVarFirst();
-  // BDD CreateNewVarBefore(BDD x);
-  // BDD CreateNewVarAfter(BDD x);
-  // BDD CreateNewVarWithIndex(BDD x, Index_t index);
-  // BDD CreateNewVarWithId(Id_t id);
+  BDD CreateNewVarFirst()
+  { return BDD(this->_bddManager, Cal_BddManagerCreateNewVarFirst(this->_bddManager)); }
+
+  BDD CreateNewVarLast()
+  { return BDD(this->_bddManager, Cal_BddManagerCreateNewVarLast(this->_bddManager)); }
+
+  BDD CreateNewVarBefore(BDD x)
+  { return BDD(this->_bddManager, Cal_BddManagerCreateNewVarBefore(this->_bddManager, x._bdd)); }
+
+  BDD CreateNewVarAfter(BDD x)
+  { return BDD(this->_bddManager, Cal_BddManagerCreateNewVarAfter(this->_bddManager, x._bdd)); }
 
   // ---------------------------------------------------------------------------
   // BDD Predicates

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -127,34 +127,34 @@ public:
   BDD Not() const
   { return BDD(this->_bddManager, Cal_BddNot(this->_bddManager, this->_bdd)); }
 
-  BDD Compose(BDD g, BDD h) const
+  BDD Compose(const BDD &g, const BDD &h) const
   { return BDD(this->_bddManager, Cal_BddCompose(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
 
-  BDD Intersects(BDD g) const
+  BDD Intersects(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddIntersects(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Implies(BDD g) const
+  BDD Implies(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddImplies(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD ITE(BDD g, BDD h) const
+  BDD ITE(const BDD &g, const BDD &h) const
   { return BDD(this->_bddManager, Cal_BddITE(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
 
-  BDD And(BDD g) const
+  BDD And(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddAnd(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Nand(BDD g) const
+  BDD Nand(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddNand(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Or(BDD g) const
+  BDD Or(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddOr(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Nor(BDD g) const
+  BDD Nor(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddNor(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Xor(BDD g) const
+  BDD Xor(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddXor(this->_bddManager, this->_bdd, g._bdd)); }
 
-  BDD Xnor(BDD g) const
+  BDD Xnor(const BDD &g) const
   { return BDD(this->_bddManager, Cal_BddXnor(this->_bddManager, this->_bdd, g._bdd)); }
 
   BDD Satisfy() const
@@ -163,15 +163,15 @@ public:
   BDD SatisfySupport() const
   { return BDD(this->_bddManager, Cal_BddSatisfySupport(this->_bddManager, this->_bdd)); }
 
-  BDD SwapVars(BDD g, BDD h) const
+  BDD SwapVars(const BDD &g, const BDD &h) const
   { return BDD(this->_bddManager, Cal_BddSwapVars(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
 
-  // BDD RelProd(BDD g) const
+  // BDD RelProd(const BDD &g) const
 
-  BDD Cofactor(BDD c) const
+  BDD Cofactor(const BDD &c) const
   { return BDD(this->_bddManager, Cal_BddCofactor(this->_bddManager, this->_bdd, c._bdd)); }
 
-  BDD Reduce(BDD c) const
+  BDD Reduce(const BDD &c) const
   { return BDD(this->_bddManager, Cal_BddReduce(this->_bddManager, this->_bdd, c._bdd)); }
 
   // ---------------------------------------------------------------------------
@@ -500,101 +500,101 @@ public:
   // ---------------------------------------------------------------------------
   // Manipulation
 
-  BDD Identity(BDD f)
+  BDD Identity(const BDD &f)
   { return f.Identity(); }
 
-  BDD Regular(BDD f)
+  BDD Regular(const BDD &f)
   { return f.Regular(); }
 
-  BDD Not(BDD f)
+  BDD Not(const BDD &f)
   { return f.Not(); }
 
-  BDD Compose(BDD f, BDD g, BDD h)
+  BDD Compose(const BDD &f, const BDD &g, const BDD &h)
   { return f.Compose(g, h); }
 
-  BDD Intersects(BDD f, BDD g)
+  BDD Intersects(const BDD &f, const BDD &g)
   { return f.Intersects(g); }
 
-  BDD Implies(BDD f, BDD g)
+  BDD Implies(const BDD &f, const BDD &g)
   { return f.Implies(g); }
 
-  BDD ITE(BDD f, BDD g, BDD h)
+  BDD ITE(const BDD &f, const BDD &g, const BDD &h)
   { return f.ITE(g, h); }
 
-  BDD And(BDD f, BDD g)
+  BDD And(const BDD &f, const BDD &g)
   { return f.And(g); }
 
   // BDD And(IT begin, IT end); (using MultiwayAnd)
 
-  BDD Nand(BDD f, BDD g)
+  BDD Nand(const BDD &f, const BDD &g)
   { return f.Nand(g); }
 
-  BDD Or(BDD f, BDD g)
+  BDD Or(const BDD &f, const BDD &g)
   { return f.Or(g); }
 
   // BDD Or(IT begin, IT end); (using MultiwayOr)
 
-  BDD Nor(BDD f, BDD g)
+  BDD Nor(const BDD &f, const BDD &g)
   { return f.Nor(g); }
 
-  BDD Xor(BDD f, BDD g)
+  BDD Xor(const BDD &f, const BDD &g)
   { return f.Xor(g); }
 
   // BDD Xor(IT begin, IT end); (using MuliwayXor)
 
-  BDD Xnor(BDD f, BDD g)
+  BDD Xnor(const BDD &f, const BDD &g)
   { return f.Xnor(g); }
 
   // container_t<BDD> PairwiseAnd(IT begin, IT end)
   // container_t<BDD> PairwiseOr(IT begin, IT end)
   // container_t<BDD> PairwiseXor(IT begin, IT end)
 
-  BDD Satisfy(BDD f)
+  BDD Satisfy(const BDD &f)
   { return f.Satisfy(); }
 
-  BDD SatisfySupport(BDD f)
+  BDD SatisfySupport(const BDD &f)
   { return f.SatisfySupport(); }
 
   // BDD Substitute(BDD f)
 
   // BDD VarSubstitute(BDD f)
 
-  BDD SwapVars(BDD f, BDD g, BDD h)
+  BDD SwapVars(const BDD &f, const BDD &g, const BDD &h)
   { return f.SwapVars(g, h); }
 
-  BDD Exists(BDD f)
+  BDD Exists(const BDD &f)
   { return BDD(this->_bddManager, Cal_BddExists(this->_bddManager, f._bdd)); }
 
-  BDD ForAll(BDD f)
+  BDD ForAll(const BDD &f)
   { return BDD(this->_bddManager, Cal_BddForAll(this->_bddManager, f._bdd)); }
 
   // BDD RelProd(BDD f, BDD g)
 
-  BDD Cofactor(BDD f, BDD c)
+  BDD Cofactor(const BDD &f, const BDD &c)
   { return f.Cofactor(c); }
 
-  BDD Reduce(BDD f, BDD c)
+  BDD Reduce(const BDD &f, const BDD &c)
   { return f.Reduce(c); }
 
-  BDD Between(BDD fMin, BDD fMax)
+  BDD Between(const BDD &fMin, const BDD &fMax)
   { return BDD(this->_bddManager, Cal_BddBetween(this->_bddManager, fMin._bdd, fMax._bdd)); }
 
   // ---------------------------------------------------------------------------
   // BDD Node Access / Traversal
 
-  BDD If(BDD f)
+  BDD If(const BDD &f) const
   { return f.If(); }
 
-  Id_t IfId(BDD f) const
+  Id_t IfId(const BDD &f) const
   { return f.Id(); }
 
-  Index_t IfIndex(BDD f) const
+  Index_t IfIndex(const BDD &f) const
   { return f.Index(); }
 
-  BDD Then(BDD f)
+  BDD Then(const BDD &f)
   { return f.Then(); }
 
-  BDD Else(BDD f)
+  BDD Else(const BDD &f)
   { return f.Else(); }
 
   // ---------------------------------------------------------------------------

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -77,6 +77,9 @@ public:
   bool IsEqualTo(const BDD &other) const
   { return Cal_BddIsEqual(this->_bddManager, this->_bdd, other._bdd); }
 
+  bool DependsOn(BDD var) const
+  { return Cal_BddDependsOn(this->_bddManager, this->_bdd, var._bdd); }
+
   // ---------------------------------------------------------------------------
   // Node traversal and Information
 
@@ -115,6 +118,9 @@ public:
   // ---------------------------------------------------------------------------
   // Operations
 
+  BDD Identity() const
+  { return BDD(this->_bddManager, Cal_BddIdentity(this->_bddManager, this->_bdd)); }
+
   BDD Regular() const
   { return BDD(this->_bddManager, Cal_BddGetRegular(this->_bddManager, this->_bdd)); }
 
@@ -123,6 +129,9 @@ public:
 
   BDD Compose(BDD g, BDD h) const
   { return BDD(this->_bddManager, Cal_BddCompose(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
+
+  BDD Intersects(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddIntersects(this->_bddManager, this->_bdd, g._bdd)); }
 
   BDD Implies(BDD g) const
   { return BDD(this->_bddManager, Cal_BddImplies(this->_bddManager, this->_bdd, g._bdd)); }
@@ -154,7 +163,8 @@ public:
   BDD SatisfySupport() const
   { return BDD(this->_bddManager, Cal_BddSatisfySupport(this->_bddManager, this->_bdd)); }
 
-  // BDD SwapVars(BDD x, BDD y) const
+  BDD SwapVars(BDD g, BDD h) const
+  { return BDD(this->_bddManager, Cal_BddSwapVars(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
 
   // BDD RelProd(BDD g) const
 
@@ -472,7 +482,8 @@ public:
   bool IsEqual(BDD f, BDD g) const
   { return f.IsEqualTo(g); }
 
-  // bool DependsOn(BDD f, BDD vars) const;
+  bool DependsOn(BDD f, BDD var) const
+  { return f.DependsOn(var); }
 
   // ---------------------------------------------------------------------------
   // BDD Information
@@ -489,7 +500,8 @@ public:
   // ---------------------------------------------------------------------------
   // Manipulation
 
-  // BDD Identity(BDD f) const
+  BDD Identity(BDD f)
+  { return f.Identity(); }
 
   BDD Regular(BDD f)
   { return f.Regular(); }
@@ -500,7 +512,8 @@ public:
   BDD Compose(BDD f, BDD g, BDD h)
   { return f.Compose(g, h); }
 
-  // BDD Intersects(BDD f, BDD g)
+  BDD Intersects(BDD f, BDD g)
+  { return f.Intersects(g); }
 
   BDD Implies(BDD f, BDD g)
   { return f.Implies(g); }
@@ -546,7 +559,8 @@ public:
 
   // BDD VarSubstitute(BDD f)
 
-  // BDD SwapVars(BDD f, BDD x, BDD y)
+  BDD SwapVars(BDD f, BDD g, BDD h)
+  { return f.SwapVars(g, h); }
 
   BDD Exists(BDD f)
   { return BDD(this->_bddManager, Cal_BddExists(this->_bddManager, f._bdd)); }

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -91,7 +91,23 @@ public:
   BDD Else() const
   { return BDD(this->_bddManager, Cal_BddElse(this->_bddManager, this->_bdd)); }
 
-  // Type BddType(BDD f);
+
+  enum Type
+  {
+    NONTERMINAL = 0,
+    ZERO = 1,
+    ONE = 2,
+    POSVAR = 3,
+    NEGVAR = 4,
+    OVERFLOW = 5,
+    CONSTANT = 6
+  };
+
+  Type BddType()
+  { return static_cast<Type>(Cal_BddType(this->_bddManager, this->_bdd)); }
+
+  unsigned long Size()
+  { return Cal_BddSize(_bddManager, this->_bdd, 0); }
 
   // ---------------------------------------------------------------------------
   // Operations
@@ -406,7 +422,7 @@ public:
   { return Cal_BddSatisfyingFraction(this->_bddManager, f._bdd); }
 
   unsigned long Size(BDD f)
-  { return Cal_BddSize(_bddManager, f._bdd, 0); }
+  { return f.Size(); }
 
   // unsigned long Size(IT begin, IT end, bool negout); (using MultipleSize)
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -79,6 +79,10 @@ public:
 
   // ---------------------------------------------------------------------------
   // Node traversal and Information
+
+  BDD If()
+  { return BDD(this->_bddManager, Cal_BddIf(this->_bddManager, this->_bdd)); }
+
   Id_t Id() const
   { return Cal_BddGetIfId(this->_bddManager, this->_bdd); }
 
@@ -90,7 +94,6 @@ public:
 
   BDD Else() const
   { return BDD(this->_bddManager, Cal_BddElse(this->_bddManager, this->_bdd)); }
-
 
   enum Type
   {
@@ -112,7 +115,54 @@ public:
   // ---------------------------------------------------------------------------
   // Operations
 
-  // TODO
+  BDD Regular() const
+  { return BDD(this->_bddManager, Cal_BddGetRegular(this->_bddManager, this->_bdd)); }
+
+  BDD Not() const
+  { return BDD(this->_bddManager, Cal_BddNot(this->_bddManager, this->_bdd)); }
+
+  BDD Compose(BDD g, BDD h) const
+  { return BDD(this->_bddManager, Cal_BddCompose(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
+
+  BDD Implies(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddImplies(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD ITE(BDD g, BDD h) const
+  { return BDD(this->_bddManager, Cal_BddITE(this->_bddManager, this->_bdd, g._bdd, h._bdd)); }
+
+  BDD And(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddAnd(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Nand(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddNand(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Or(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddOr(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Nor(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddNor(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Xor(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddXor(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Xnor(BDD g) const
+  { return BDD(this->_bddManager, Cal_BddXnor(this->_bddManager, this->_bdd, g._bdd)); }
+
+  BDD Satisfy() const
+  { return BDD(this->_bddManager, Cal_BddSatisfy(this->_bddManager, this->_bdd)); }
+
+  BDD SatisfySupport() const
+  { return BDD(this->_bddManager, Cal_BddSatisfySupport(this->_bddManager, this->_bdd)); }
+
+  // BDD SwapVars(BDD x, BDD y) const
+
+  // BDD RelProd(BDD g) const
+
+  BDD Cofactor(BDD c) const
+  { return BDD(this->_bddManager, Cal_BddCofactor(this->_bddManager, this->_bdd, c._bdd)); }
+
+  BDD Reduce(BDD c) const
+  { return BDD(this->_bddManager, Cal_BddReduce(this->_bddManager, this->_bdd, c._bdd)); }
 
   // ---------------------------------------------------------------------------
   // Operation Overloading
@@ -142,28 +192,28 @@ public:
   }
 
   bool operator== (const BDD &other) const
-  { return IsEqualTo(other); }
+  { return this->IsEqualTo(other); }
 
   bool  operator!= (const BDD &other) const
   { return !(*this == other); }
 
   BDD  operator~ () const
-  { return BDD(this->_bddManager, Cal_BddNot(this->_bddManager, this->_bdd)); }
+  { return this->Not(); }
 
   BDD  operator& (const BDD &other) const
-  { return BDD(this->_bddManager, Cal_BddAnd(this->_bddManager, this->_bdd, other._bdd)); }
+  { return this->And(other); }
 
   BDD& operator&= (const BDD &other)
   { return (*this = (*this) & other); }
 
   BDD  operator| (const BDD &other) const
-  { return BDD(this->_bddManager, Cal_BddOr(this->_bddManager, this->_bdd, other._bdd)); }
+  { return this->Or(other); }
 
   BDD& operator|= (const BDD &other)
   { return (*this = (*this) | other); }
 
   BDD  operator^ (const BDD &other) const
-  { return BDD(this->_bddManager, Cal_BddXor(this->_bddManager, this->_bdd, other._bdd)); }
+  { return this->Xor(other); }
 
   BDD& operator^= (const BDD &other)
   { return (*this = (*this) ^ other); }
@@ -442,55 +492,55 @@ public:
   // BDD Identity(BDD f) const
 
   BDD Regular(BDD f)
-  { return BDD(this->_bddManager, Cal_BddGetRegular(this->_bddManager, f._bdd)); }
+  { return f.Regular(); }
 
   BDD Not(BDD f)
-  { return BDD(this->_bddManager, Cal_BddNot(this->_bddManager, f._bdd)); }
+  { return f.Not(); }
 
   BDD Compose(BDD f, BDD g, BDD h)
-  { return BDD(this->_bddManager, Cal_BddCompose(this->_bddManager, f._bdd, g._bdd, h._bdd)); }
+  { return f.Compose(g, h); }
 
   // BDD Intersects(BDD f, BDD g)
 
   BDD Implies(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddImplies(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Implies(g); }
 
   BDD ITE(BDD f, BDD g, BDD h)
-  { return BDD(this->_bddManager, Cal_BddITE(this->_bddManager, f._bdd, g._bdd, h._bdd)); }
+  { return f.ITE(g, h); }
 
   BDD And(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddAnd(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.And(g); }
 
   // BDD And(IT begin, IT end); (using MultiwayAnd)
 
   BDD Nand(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddNand(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Nand(g); }
 
   BDD Or(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddOr(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Or(g); }
 
   // BDD Or(IT begin, IT end); (using MultiwayOr)
 
   BDD Nor(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddNor(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Nor(g); }
 
   BDD Xor(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddXor(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Xor(g); }
 
   // BDD Xor(IT begin, IT end); (using MuliwayXor)
 
   BDD Xnor(BDD f, BDD g)
-  { return BDD(this->_bddManager, Cal_BddXnor(this->_bddManager, f._bdd, g._bdd)); }
+  { return f.Xnor(g); }
 
   // container_t<BDD> PairwiseAnd(IT begin, IT end)
   // container_t<BDD> PairwiseOr(IT begin, IT end)
   // container_t<BDD> PairwiseXor(IT begin, IT end)
 
   BDD Satisfy(BDD f)
-  { return BDD(this->_bddManager, Cal_BddSatisfy(this->_bddManager, f._bdd)); }
+  { return f.Satisfy(); }
 
   BDD SatisfySupport(BDD f)
-  { return BDD(this->_bddManager, Cal_BddSatisfySupport(this->_bddManager, f._bdd)); }
+  { return f.SatisfySupport(); }
 
   // BDD Substitute(BDD f)
 
@@ -507,10 +557,10 @@ public:
   // BDD RelProd(BDD f, BDD g)
 
   BDD Cofactor(BDD f, BDD c)
-  { return BDD(this->_bddManager, Cal_BddCofactor(this->_bddManager, f._bdd, c._bdd)); }
+  { return f.Cofactor(c); }
 
   BDD Reduce(BDD f, BDD c)
-  { return BDD(this->_bddManager, Cal_BddReduce(this->_bddManager, f._bdd, c._bdd)); }
+  { return f.Reduce(c); }
 
   BDD Between(BDD fMin, BDD fMax)
   { return BDD(this->_bddManager, Cal_BddBetween(this->_bddManager, fMin._bdd, fMax._bdd)); }
@@ -519,11 +569,13 @@ public:
   // BDD Node Access / Traversal
 
   BDD If(BDD f)
-  { return BDD(this->_bddManager, Cal_BddIf(this->_bddManager, f._bdd)); }
+  { return f.If(); }
 
-  // Id_t IfId(BDD f) const
+  Id_t IfId(BDD f) const
+  { return f.Id(); }
 
-  // Index_t IfIndex(BDD f) const
+  Index_t IfIndex(BDD f) const
+  { return f.Index(); }
 
   BDD Then(BDD f)
   { return f.Then(); }

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -387,7 +387,7 @@ public:
   { return BDD(this->_bddManager, Cal_BddManagerGetVarWithId(this->_bddManager, id)); }
 
   BDD Index(Index_t idx) const
-  { return BDD(this->_bddManager, Cal_BddManagerGetVarWithId(this->_bddManager, idx)); }
+  { return BDD(this->_bddManager, Cal_BddManagerGetVarWithIndex(this->_bddManager, idx)); }
 
   BDD CreateNewVarFirst()
   { return BDD(this->_bddManager, Cal_BddManagerCreateNewVarFirst(this->_bddManager)); }

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -251,10 +251,11 @@ public:
     // TODO: Cal_BddManagerSetParameters
   }
 
-  // TODO: allow multiple copies to access Cal (requires reference counting)
+  // TODO: copy constructor (requires reference counting)
   Cal(const Cal &o) = delete;
 
   // TODO: move constructor
+  Cal(Cal &&o) = delete;
 
   ~Cal()
   {

--- a/test/calBddReorderTest.c
+++ b/test/calBddReorderTest.c
@@ -156,11 +156,11 @@ main(int argc, char **argv)
   printf("%%%%%%%%%%%% Reordering %%%%%%%%%%%%%%%%%%%\n");
   if (siftFlag){
     printf("Using Sift Technique\n");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_SIFT);
+    Cal_BddDynamicReordering(bddManager, CAL_REORDER_SIFT, CAL_REORDER_METHOD_DF);
   }
   else{
     printf("Using Window Technique\n");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_WINDOW);
+    Cal_BddDynamicReordering(bddManager, CAL_REORDER_WINDOW, CAL_REORDER_METHOD_DF);
   }
   Cal_BddReorder(bddManager);
   printf("CPU time: %-8.2f\t Elapsed Time = %-10ld\n", cpuTime(), elapsedTime());

--- a/test/calTest.c
+++ b/test/calTest.c
@@ -1561,20 +1561,20 @@ TestReorderBlock(Cal_BddManager bddManager, TruthTable_t table, Cal_Bdd f)
   Cal_Bdd newFunction;
   Cal_Block block1, block2, block3, block4;
   int i;
-  
+
   /*if (CalUtilRandom()&0x1){*/
   if (1){
     fprintf(stdout, "Using Window\n");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_WINDOW);
+    Cal_BddDynamicReordering(bddManager, CAL_REORDER_WINDOW, CAL_REORDER_METHOD_DF);
   }
   else{
     fprintf(stdout, "Using Sift\n");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_SIFT);
+    Cal_BddDynamicReordering(bddManager, CAL_REORDER_SIFT, CAL_REORDER_METHOD_DF);
   }
   /* Create some blocks */
   block1 = Cal_BddNewVarBlock(bddManager,
                               vars[bddManager->indexToId[0]-1],
-                              4); 
+                              4);
   block2 = Cal_BddNewVarBlock(bddManager,
                               vars[bddManager->indexToId[4]-1],
                               4);
@@ -1605,21 +1605,26 @@ static void
 TestReorder(Cal_BddManager bddManager, TruthTable_t table, Cal_Bdd f)
 {
   Cal_Bdd newFunction;
-  
+
+  int technique, method;
+
   if (CalUtilRandom()&0x1){
     fprintf(stdout, "Using Window");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_WINDOW);
+    technique = CAL_REORDER_WINDOW;
   } else {
     fprintf(stdout, "Using Sift");
-    Cal_BddDynamicReordering(bddManager, CAL_REORDER_SIFT);
+    technique = CAL_REORDER_SIFT;
   }
   if (CalUtilRandom()&0x1) {
     fprintf(stdout, " (BF)\n");
-    bddManager->reorderMethod = CAL_REORDER_METHOD_BF;
+    method = CAL_REORDER_METHOD_BF;
   } else {
     fprintf(stdout, " (DF)\n");
-    bddManager->reorderMethod = CAL_REORDER_METHOD_DF;
+    method = CAL_REORDER_METHOD_DF;
   }
+
+  Cal_BddDynamicReordering(bddManager, technique, method);
+
   Cal_BddReorder(bddManager);
   newFunction = EncodingToBdd(table);
   if (Cal_BddIsEqual(bddManager, f, newFunction) == 0){


### PR DESCRIPTION
- [x] Reordering the C api to be able to group associated functions together
- [x] Reorder C++ api accordingly
- [x] Move most logic inside of `BDD` class, making many of `Cal` functions an alias.
- [x] Make most the CAL BDD operations static functions
- [x] Make calls use borrowing rather than a copy