### PR TITLE
Add moving ownership of Cal BDD Manager

### DIFF
--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -371,15 +371,6 @@ class Cal
 
   // ---------------------------------------------------------------------------
   // Fields
-private:
-  //           TODO -----------------------------------------------
-  //                             Movable Cal object
-  //             ----------------------------------------------- TODO
-  //
-  //   Use a 'std::unique_ptr' to handle the semantics of single ownership of
-  //   this 'Cal_BddManager' pointer. The 'Cal_BddManagerQuit' function is then
-  //   the managed pointer's deleter.
-  //
   //           TODO -----------------------------------------------
   //              Multiple Cal objects for the same Cal_BddManager
   //             ----------------------------------------------- TODO
@@ -412,15 +403,20 @@ public:
     }
   }
 
-  // TODO: copy constructor (requires reference counting)
+  // TODO: Copy constructor (requires reference counting)
   Cal(const Cal &o) = delete;
 
-  // TODO: move constructor (requires ownership or reference counting)
-  Cal(Cal &&o) = delete;
+  // Move ownership of C object.
+  Cal(Cal &&o)
+    : _bddManager(o._bddManager)
+  {
+    o._bddManager = nullptr;
+  }
 
   ~Cal()
   {
-    Cal_BddManagerQuit(this->_bddManager);
+    if (this->_bddManager)
+      Cal_BddManagerQuit(this->_bddManager);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
One could also implement the same by using the `std::unique_ptr<Cal_BddManagerStruct, int(*)(Cal_BddManager)> ` but this...
1. ... is simpler and makes for slightly cleaner code (there is no need to add a `.get()` everywhere.
2. ... keeps the dependency on the `std` as small as possible. In fact, we may want to also eliminate the dependency on the `std::vector<_>`? This does not really create any issues, since `calObj.hh` is header-only and id always compiled by the user; hence, one does not run into any issues with different versions of the `std` library.