### PR TITLE
Fix build with clang

### DIFF
--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -292,7 +292,7 @@ public:
   ///               negative-output pointers (complement edges).
   //////////////////////////////////////////////////////////////////////////////
   unsigned long Size(bool negout = true) const
-  { return Cal_BddSize(this->_bddManager, this->_bdd, 0); }
+  { return Cal_BddSize(this->_bddManager, this->_bdd, negout); }
 
   //////////////////////////////////////////////////////////////////////////////
   /// \copybrief Cal_BddSatisfyingFraction

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -1201,7 +1201,7 @@ public:
     std::vector<Cal_Bdd> c_arg =
       BDD::C_Bdd_vector(this->_bddManager, std::move(begin), std::move(end));
 
-    const BDD res = Cal_BddMultiwayAnd(this->_bddManager, c_arg.data());
+    const BDD res(this->_bddManager, Cal_BddMultiwayAnd(this->_bddManager, c_arg.data()));
 
     BDD::Free(this->_bddManager, c_arg.begin(), c_arg.end());
 
@@ -1242,7 +1242,7 @@ public:
     std::vector<Cal_Bdd> c_arg =
       BDD::C_Bdd_vector(this->_bddManager, std::move(begin), std::move(end));
 
-    const BDD res = Cal_BddMultiwayOr(this->_bddManager, c_arg.data());
+    const BDD res(this->_bddManager, Cal_BddMultiwayOr(this->_bddManager, c_arg.data()));
 
     BDD::Free(this->_bddManager, c_arg.begin(), c_arg.end());
 
@@ -1283,7 +1283,7 @@ public:
     std::vector<Cal_Bdd> c_arg =
       BDD::C_Bdd_vector(this->_bddManager, std::move(begin), std::move(end));
 
-    const BDD res = Cal_BddMultiwayXor(this->_bddManager, c_arg.data());
+    const BDD res(this->_bddManager, Cal_BddMultiwayXor(this->_bddManager, c_arg.data()));
 
     BDD::Free(this->_bddManager, c_arg.begin(), c_arg.end());
 

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -40,8 +40,8 @@
 #define _CALOBJ
 
 extern "C" {
-#include <cal.h>
-#include <calInt.h>
+#include "cal.h"
+#include "calInt.h"
 }
 
 #include <vector>

--- a/src/calObj.hh
+++ b/src/calObj.hh
@@ -609,7 +609,7 @@ protected:
 
     out.push_back(Cal_BddNull(bddManager));
 
-    return std::move(out);
+    return out;
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -628,7 +628,7 @@ protected:
       res.push_back(BDD(bddManager, bddArray[i]));
     }
 
-    return std::move(res);
+    return res;
   }
 
   /// \endcond


### PR DESCRIPTION
This also forwards the `negout` parameter of the `Size()` method to `Cal_BddSize()`, which will probably be useful for #31.